### PR TITLE
Add option to set custom tab level indicator marker colors

### DIFF
--- a/src/defaults.js
+++ b/src/defaults.js
@@ -198,7 +198,8 @@ export const CUSTOM_CSS_VARS = {
   tabs_shadow: null,
   tabs_activated_shadow: null,
   tabs_selected_shadow: null,
-
+  tabs_lvl_indicator_bg: null,
+  
   bookmarks_bookmark_height: null,
   bookmarks_folder_height: null,
   bookmarks_separator_height: null,

--- a/src/locales/en.styles.js
+++ b/src/locales/en.styles.js
@@ -67,7 +67,7 @@ export default {
   'styles.tabs_shadow': { message: 'Shadow' },
   'styles.tabs_activated_shadow': { message: 'Active tab shadow' },
   'styles.tabs_selected_shadow': { message: 'Selected tab shadow' },
-  'styles.tabs_lvl_indicator_bg': { message: 'Tab Level Indicator Color'},
+  'styles.tabs_lvl_indicator_bg': { message: 'Tab level indicator color'},
 
   // --- Bookmarks
   'styles.bookmarks_title': { message: 'Bookmarks' },

--- a/src/locales/en.styles.js
+++ b/src/locales/en.styles.js
@@ -67,6 +67,7 @@ export default {
   'styles.tabs_shadow': { message: 'Shadow' },
   'styles.tabs_activated_shadow': { message: 'Active tab shadow' },
   'styles.tabs_selected_shadow': { message: 'Selected tab shadow' },
+  'styles.tabs_lvl_indicator_bg': { message: 'Tab Level Indicator Color'},
 
   // --- Bookmarks
   'styles.bookmarks_title': { message: 'Bookmarks' },

--- a/src/locales/ru.styles.js
+++ b/src/locales/ru.styles.js
@@ -67,6 +67,7 @@ export default {
   'styles.tabs_shadow': { message: 'Тень' },
   'styles.tabs_activated_shadow': { message: 'Тень активного таба' },
   'styles.tabs_selected_shadow': { message: 'Тень выделенного таба' },
+  'styles.tabs_lvl_indicator_bg': { message: 'Цвет индикатора уровня вкладки'},
 
   // --- Bookmarks
   'styles.bookmarks_title': { message: 'Закладки' },

--- a/src/page.settings/components/styles-editor.vue
+++ b/src/page.settings/components/styles-editor.vue
@@ -367,7 +367,7 @@
         @change="updateCSSVar('tabs_selected_shadow')"
         @toggle="toggleCSSVar('tabs_selected_shadow')")
         
-      style-field(
+      color-style-field(
         v-model="cssVars.tabs_lvl_indicator_bg"
         :label="'styles.tabs_lvl_indicator_bg'"
         :name="'--tabs-lvl-indicator-bg'"

--- a/src/page.settings/components/styles-editor.vue
+++ b/src/page.settings/components/styles-editor.vue
@@ -366,7 +366,15 @@
         :or="'---'"
         @change="updateCSSVar('tabs_selected_shadow')"
         @toggle="toggleCSSVar('tabs_selected_shadow')")
-
+        
+      style-field(
+        v-model="cssVars.tabs_lvl_indicator_bg"
+        :label="'styles.tabs_lvl_indicator_bg'"
+        :name="'--tabs-lvl-indicator-bg'"
+        :or="'---'"
+        @change="updateCSSVar('tabs_lvl_indicator_bg')"
+        @toggle="toggleCSSVar('tabs_lvl_indicator_bg')")
+        
     section
       h2 {{t('styles.bookmarks_title')}}
       style-field(

--- a/src/sidebar/components/tab.vue
+++ b/src/sidebar/components/tab.vue
@@ -45,8 +45,7 @@
   .close(v-if="$store.state.showTabRmBtn" @mousedown.stop="onCloseClick" @mouseup.stop="")
     svg: use(xlink:href="#icon_remove")
   .ctx(v-if="color")
-  .t-box: .title {{tab.index}} - {{tab.id}} - {{tab.panelId[0]}} {{tab.title}}
-  //- .t-box: .title {{tab.title}}
+  .t-box: .title {{tab.title}}
 </template>
 
 

--- a/src/sidebar/components/tab.vue
+++ b/src/sidebar/components/tab.vue
@@ -45,7 +45,8 @@
   .close(v-if="$store.state.showTabRmBtn" @mousedown.stop="onCloseClick" @mouseup.stop="")
     svg: use(xlink:href="#icon_remove")
   .ctx(v-if="color")
-  .t-box: .title {{tab.title}}
+  .t-box: .title {{tab.index}} - {{tab.id}} - {{tab.panelId[0]}} {{tab.title}}
+  //- .t-box: .title {{tab.title}}
 </template>
 
 

--- a/src/styles/themes/default/tabs.tab.styl
+++ b/src/styles/themes/default/tabs.tab.styl
@@ -75,16 +75,16 @@
 
 #root[data-tabs-tree-lvl-marks] .Tab .lvl-wrapper:before
   box(block)
-  box-shadow: calc(var(--tabs-indent) / -2) 0 0 0 var(--inactive-fg),
-              calc(var(--tabs-indent) * -1.5) 0 0 0 var(--inactive-fg),
-              calc(var(--tabs-indent) * -2.5) 0 0 0 var(--inactive-fg),
-              calc(var(--tabs-indent) * -3.5) 0 0 0 var(--inactive-fg),
-              calc(var(--tabs-indent) * -4.5) 0 0 0 var(--inactive-fg),
-              calc(var(--tabs-indent) * -5.5) 0 0 0 var(--inactive-fg),
-              calc(var(--tabs-indent) * -6.5) 0 0 0 var(--inactive-fg),
-              calc(var(--tabs-indent) * -7.5) 0 0 0 var(--inactive-fg),
-              calc(var(--tabs-indent) * -8.5) 0 0 0 var(--inactive-fg),
-              calc(var(--tabs-indent) * -9.5) 0 0 0 var(--inactive-fg)
+  box-shadow: calc(var(--tabs-indent) / -2) 0 0 0 var(--tabs-lvl-indicator-bg),
+              calc(var(--tabs-indent) * -1.5) 0 0 0 var(--tabs-lvl-indicator-bg),
+              calc(var(--tabs-indent) * -2.5) 0 0 0 var(--tabs-lvl-indicator-bg),
+              calc(var(--tabs-indent) * -3.5) 0 0 0 var(--tabs-lvl-indicator-bg),
+              calc(var(--tabs-indent) * -4.5) 0 0 0 var(--tabs-lvl-indicator-bg),
+              calc(var(--tabs-indent) * -5.5) 0 0 0 var(--tabs-lvl-indicator-bg),
+              calc(var(--tabs-indent) * -6.5) 0 0 0 var(--tabs-lvl-indicator-bg),
+              calc(var(--tabs-indent) * -7.5) 0 0 0 var(--tabs-lvl-indicator-bg),
+              calc(var(--tabs-indent) * -8.5) 0 0 0 var(--tabs-lvl-indicator-bg),
+              calc(var(--tabs-indent) * -9.5) 0 0 0 var(--tabs-lvl-indicator-bg)
 
 // ---
 // -- Drag layer

--- a/src/styles/themes/default/vars.styl
+++ b/src/styles/themes/default/vars.styl
@@ -131,7 +131,7 @@
     --tabs-selected-fg: #ffffff
     --tabs-loading-fg: #47cfff
     --tabs-update-badge-bg: #00e9fb
-    --tabs-lvl-indicator-bg: #a2a2a2
+    --tabs-lvl-indicator-bg: #5c5c5c
   &[data-style="light"]
     --tabs-fg: #323232
     --tabs-fg-hover: #000000

--- a/src/styles/themes/default/vars.styl
+++ b/src/styles/themes/default/vars.styl
@@ -131,6 +131,7 @@
     --tabs-selected-fg: #ffffff
     --tabs-loading-fg: #47cfff
     --tabs-update-badge-bg: #00e9fb
+    --tabs-lvl-indicator-bg: #a2a2a2
   &[data-style="light"]
     --tabs-fg: #323232
     --tabs-fg-hover: #000000
@@ -143,6 +144,7 @@
     --tabs-selected-bg: #44a4f4
     --tabs-selected-fg: #ffffff
     --tabs-update-badge-bg: #01acda
+    --tabs-lvl-indicator-bg: #a2a2a2
 
   // Bookmarks
   &[data-style="dark"]

--- a/src/styles/themes/tactile/tabs.tab.styl
+++ b/src/styles/themes/tactile/tabs.tab.styl
@@ -118,16 +118,16 @@
 
 #root[data-tabs-tree-lvl-marks] .Tab .lvl-wrapper:before
   box(block)
-  box-shadow: calc(var(--tabs-indent) / -2) 0 0 0 #00000064,
-              calc(var(--tabs-indent) * -1.5) 0 0 0 #00000064,
-              calc(var(--tabs-indent) * -2.5) 0 0 0 #00000064,
-              calc(var(--tabs-indent) * -3.5) 0 0 0 #00000064,
-              calc(var(--tabs-indent) * -4.5) 0 0 0 #00000064,
-              calc(var(--tabs-indent) * -5.5) 0 0 0 #00000064,
-              calc(var(--tabs-indent) * -6.5) 0 0 0 #00000064,
-              calc(var(--tabs-indent) * -7.5) 0 0 0 #00000064,
-              calc(var(--tabs-indent) * -8.5) 0 0 0 #00000064,
-              calc(var(--tabs-indent) * -9.5) 0 0 0 #00000032
+  box-shadow: calc(var(--tabs-indent) / -2) 0 0 0 var(--tabs-lvl-indicator-bg),
+              calc(var(--tabs-indent) * -1.5) 0 0 0 var(--tabs-lvl-indicator-bg),
+              calc(var(--tabs-indent) * -2.5) 0 0 0 var(--tabs-lvl-indicator-bg),
+              calc(var(--tabs-indent) * -3.5) 0 0 0 var(--tabs-lvl-indicator-bg),
+              calc(var(--tabs-indent) * -4.5) 0 0 0 var(--tabs-lvl-indicator-bg),
+              calc(var(--tabs-indent) * -5.5) 0 0 0 var(--tabs-lvl-indicator-bg),
+              calc(var(--tabs-indent) * -6.5) 0 0 0 var(--tabs-lvl-indicator-bg),
+              calc(var(--tabs-indent) * -7.5) 0 0 0 var(--tabs-lvl-indicator-bg),
+              calc(var(--tabs-indent) * -8.5) 0 0 0 var(--tabs-lvl-indicator-bg),
+              calc(var(--tabs-indent) * -9.5) 0 0 0 var(--tabs-lvl-indicator-bg)
 
 // ---
 // -- Drag layer

--- a/src/styles/themes/tactile/vars.styl
+++ b/src/styles/themes/tactile/vars.styl
@@ -141,7 +141,7 @@
     --tabs-child-count-fg: #ffffff
     --tabs-close-fg: #df512d
     --tabs-close-hover-fg: #ff613d
-    --tabs-lvl-indicator-bg: #fff
+    --tabs-lvl-indicator-bg: #808080
   &[data-style="light"]
     --tabs-fg: #363636
     --tabs-fg-hover: #323232
@@ -158,7 +158,7 @@
     --tabs-child-count-fg: #000000
     --tabs-close-fg: #000000aa
     --tabs-close-hover-fg: #000000
-    --tabs-lvl-indicator-bg: #000000
+    --tabs-lvl-indicator-bg: #606060
 
   // Bookmarks
   &[data-style="dark"]

--- a/src/styles/themes/tactile/vars.styl
+++ b/src/styles/themes/tactile/vars.styl
@@ -141,6 +141,7 @@
     --tabs-child-count-fg: #ffffff
     --tabs-close-fg: #df512d
     --tabs-close-hover-fg: #ff613d
+    --tabs-lvl-indicator-bg: #fff
   &[data-style="light"]
     --tabs-fg: #363636
     --tabs-fg-hover: #323232
@@ -157,6 +158,7 @@
     --tabs-child-count-fg: #000000
     --tabs-close-fg: #000000aa
     --tabs-close-hover-fg: #000000
+    --tabs-lvl-indicator-bg: #000000
 
   // Bookmarks
   &[data-style="dark"]


### PR DESCRIPTION
This commit adds the `--tabs-lvl-indicator-bg` custom CSS variable along with an entry in the style editor that allows a custom color to be set from the interface.

The main reason I have added this was because in order to change the color using custom CSS, you had to completely override the box-shadow CSS option for the indicators as the colors had been hard coded into it. 

This pull request allows the color to be set in the style editor or in custom CSS from a single css variable.

**Note**: The Russian string translation in `src/locales/ru.styles.js` was generated using Google Translate which I know to not be the most reliable English->AnyOtherLanguage translation source. Feel free to change the translation if it is not correct.