### PR TITLE
Fixed: Open new tab in container if required

### DIFF
--- a/src/sidebar/handlers/tabs.js
+++ b/src/sidebar/handlers/tabs.js
@@ -69,6 +69,11 @@ function onTabCreated(tab) {
     if (!autoGroupTab) tab.openerTabId = this.actions.getParentForNewTab(panel, tab.openerTabId)
   }
 
+  // Put new tab in container if configured so
+  if (panel && panel.newTabCtx !== 'none') {
+    tab.cookieStoreId = panel.newTabCtx
+  }
+
   // If new tab has wrong possition - move it
   if (!tab.pinned && tab.index !== index) {
     tab.destPanelId = panel.id


### PR DESCRIPTION
New tabs are opened in the panel's container if they're configured to do so.

Fixes #305.
Fixes #316.

Thanks for this great addon.