### PR TITLE
Fixed: New tabs stay in active panel when "hide tabs of inactive panel" is on

### DIFF
--- a/src/sidebar/actions/tabs.js
+++ b/src/sidebar/actions/tabs.js
@@ -29,6 +29,10 @@ async function loadTabsFromGlobalStorage() {
   let idsMap = {}
   let activeTab
 
+  const hideInact = this.state.hideInact
+  const toMoveBeforeActivePanel = [];
+  const toMoveAfterActivePanel = [];
+
   // Find most appropriate data-set to restoring prev tabs state
   tabsData = Utils.findDataForTabs(tabs, tabsData)
   if (!tabsData.length) {
@@ -90,6 +94,16 @@ async function loadTabsFromGlobalStorage() {
     if (!panel) {
       if (tab.pinned) tab.panelId = DEFAULT_CTX_ID
       else tab.panelId = lastPanel.id
+
+      // Record new tabs that need to be repositioned (for keeping new tabs
+      // within active panel when hide inactive panel is enabled) 
+      if (hideInact) {
+        if (activePanel.index < lastPanel.index) {
+          toMoveAfterActivePanel.push(tab)
+        } else if (activePanel.index > lastPanel.index) {
+          toMoveBeforeActivePanel.push(tab)
+        }
+      }
     } else {
       if (!tab.pinned) {
         // Check order of panels
@@ -132,6 +146,17 @@ async function loadTabsFromGlobalStorage() {
     let target = Utils.findSuccessorTab(this.state, activeTab)
     if (target) browser.tabs.moveInSuccession([activeTab.id], target.id)
   }
+
+  // Move tabs
+  if (hideInact) {
+    if (toMoveBeforeActivePanel.length) {
+      await this.actions.moveDroppedNodes(activePanel.startIndex, -1, toMoveBeforeActivePanel, toMoveBeforeActivePanel[0].pinned, activePanel)
+    }
+    if (toMoveAfterActivePanel.length) {
+      let index = activePanel.tabs.length ? activePanel.endIndex + 1 : activePanel.startIndex
+      await this.actions.moveDroppedNodes(index, -1, toMoveAfterActivePanel, toMoveAfterActivePanel[0].pinned, activePanel)
+    }
+  }
 }
 
 /**
@@ -159,6 +184,10 @@ async function loadTabsFromSessionStorage() {
   let offset = 0
   let activeTab
   let idsMap = {}
+
+  const hideInact = this.state.hideInact
+  const toMoveBeforeActivePanel = [];
+  const toMoveAfterActivePanel = [];
 
   // Set tabs initial props and update state
   this.state.tabsMap = []
@@ -205,6 +234,16 @@ async function loadTabsFromSessionStorage() {
     if (!panel) {
       if (tab.pinned) tab.panelId = DEFAULT_CTX_ID
       else tab.panelId = lastPanel.id
+
+      // Record new tabs that need to be repositioned (for keeping new tabs
+      // within active panel when hide inactive panel is enabled) 
+      if (hideInact) {
+        if (activePanel.index < lastPanel.index) {
+          toMoveAfterActivePanel.push(tab)
+        } else if (activePanel.index > lastPanel.index) {
+          toMoveBeforeActivePanel.push(tab)
+        }
+      }
     } else {
       if (!tab.pinned) {
         // Check order of panels
@@ -246,6 +285,17 @@ async function loadTabsFromSessionStorage() {
   if (this.state.activateAfterClosing !== 'none' && activeTab) {
     let target = Utils.findSuccessorTab(this.state, activeTab)
     if (target) browser.tabs.moveInSuccession([activeTab.id], target.id)
+  }
+
+  // Move tabs
+  if (hideInact) {
+    if (toMoveBeforeActivePanel.length) {
+      await this.actions.moveDroppedNodes(activePanel.startIndex, -1, toMoveBeforeActivePanel, toMoveBeforeActivePanel[0].pinned, activePanel)
+    }
+    if (toMoveAfterActivePanel.length) {
+      let index = activePanel.tabs.length ? activePanel.endIndex + 1 : activePanel.startIndex
+      await this.actions.moveDroppedNodes(index, -1, toMoveAfterActivePanel, toMoveAfterActivePanel[0].pinned, activePanel)
+    }
   }
 }
 

--- a/src/sidebar/actions/tabs.js
+++ b/src/sidebar/actions/tabs.js
@@ -30,8 +30,8 @@ async function loadTabsFromGlobalStorage() {
   let activeTab
 
   const hideInact = this.state.hideInact
-  const toMoveBeforeActivePanel = [];
-  const toMoveAfterActivePanel = [];
+  const toMoveBeforeActivePanel = []
+  const toMoveAfterActivePanel = []
 
   // Find most appropriate data-set to restoring prev tabs state
   tabsData = Utils.findDataForTabs(tabs, tabsData)
@@ -96,7 +96,7 @@ async function loadTabsFromGlobalStorage() {
       else tab.panelId = lastPanel.id
 
       // Record new tabs that need to be repositioned (for keeping new tabs
-      // within active panel when hide inactive panel is enabled) 
+      // within active panel when "hide tabs of inactive panel" is enabled) 
       if (hideInact) {
         if (activePanel.index < lastPanel.index) {
           toMoveAfterActivePanel.push(tab)
@@ -236,7 +236,7 @@ async function loadTabsFromSessionStorage() {
       else tab.panelId = lastPanel.id
 
       // Record new tabs that need to be repositioned (for keeping new tabs
-      // within active panel when hide inactive panel is enabled) 
+      // within active panel when "hide tabs of inactive panel" is enabled) 
       if (hideInact) {
         if (activePanel.index < lastPanel.index) {
           toMoveAfterActivePanel.push(tab)


### PR DESCRIPTION
I prefer using firefox with this extension closed. However, when "hide tabs of inactive panel" is enabled and I open a bunch of new tabs without the sidebar, they always go to the last panel after I reopened it. It was quite annoying for me. I would like to see changes in tabs reflected in the active panel while the extension is inactive. This PR fixes this issue and hopefully closes #125.

Thank you for this awesome addon!

Copied from #125:

## Steps to reproduce

Enable "Hide tabs of inactive panel"
Have some configured Panels in Sidebery
Open Firefox side strip with Sidebery
Switch to "Default" panel in Sidebery
Close Firefox side strip with Sidebery
Create new tab in Firefox
Open Firefox side strip with Sidebery to check membership of tabs into Panels
## Expected behavior

The new tabs should be in Default panel (or other panel I switched to before closing Sidebery side strip)
## Actual behavior

New tabs are in different Panel (probably the last created?). And also Sidebery shows that this Panel is actual one (not the one I left before closing Sidebery side strip).

