### PR TITLE
Fixes #539 - Don't use the forbidden text/x-moz-text-internal

### DIFF
--- a/src/sidebar/components/bookmark.vue
+++ b/src/sidebar/components/bookmark.vue
@@ -213,7 +213,6 @@ export default {
       State.dragXStart = e.clientX
 
       // Set drag info
-      e.dataTransfer.setData('text/x-moz-text-internal', this.node.url)
       e.dataTransfer.setData('text/uri-list', this.node.url)
       e.dataTransfer.setData('text/plain', this.node.url)
       e.dataTransfer.effectAllowed = 'move'

--- a/src/sidebar/components/bookmarks-folder.vue
+++ b/src/sidebar/components/bookmarks-folder.vue
@@ -262,7 +262,6 @@ export default {
       walker(State.bookmarks)
 
       // Set drag info
-      e.dataTransfer.setData('text/x-moz-text-internal', this.node.url)
       e.dataTransfer.setData('text/uri-list', this.node.url)
       e.dataTransfer.setData('text/plain', this.node.url)
       e.dataTransfer.effectAllowed = 'move'

--- a/src/sidebar/components/bookmarks-separator.vue
+++ b/src/sidebar/components/bookmarks-separator.vue
@@ -171,7 +171,6 @@ export default {
       walker(State.bookmarks)
 
       // Set drag info
-      e.dataTransfer.setData('text/x-moz-text-internal', this.node.url)
       e.dataTransfer.setData('text/uri-list', this.node.url)
       e.dataTransfer.setData('text/plain', this.node.url)
       e.dataTransfer.effectAllowed = 'move'

--- a/src/sidebar/mixins/tab.js
+++ b/src/sidebar/mixins/tab.js
@@ -294,7 +294,6 @@ export default {
       State.selected = []
 
       // Set drag info
-      e.dataTransfer.setData('text/x-moz-text-internal', this.tab.url)
       e.dataTransfer.setData('text/x-moz-url', this.tab.url + '\n' + this.tab.title)
       e.dataTransfer.setData('text/x-moz-url-data', this.tab.url)
       e.dataTransfer.setData('text/x-moz-url-desc', this.tab.title)


### PR DESCRIPTION
I think this isn't necessary, because text/plain should be able to
replace it.