### PR TITLE
Fixes #583 - Adjust horizontal threshold for pixel scrolling

### DIFF
--- a/src/sidebar/actions/panels.js
+++ b/src/sidebar/actions/panels.js
@@ -313,7 +313,7 @@ function switchPanel(dir = 0) {
   this.state.switchPanelPause = setTimeout(() => {
     clearTimeout(this.state.switchPanelPause)
     this.state.switchPanelPause = null
-  }, 128)
+  }, 512)
 
   this.actions.closeCtxMenu()
   this.actions.resetSelection()

--- a/src/sidebar/sidebar.vue
+++ b/src/sidebar/sidebar.vue
@@ -169,8 +169,9 @@ export default {
       if (State.ctxMenu) Actions.closeCtxMenu()
 
       if (State.hScrollThroughPanels) {
-        if (e.deltaX > 0) return Actions.switchPanel(1)
-        if (e.deltaX < 0) return Actions.switchPanel(-1)
+        let threshold = e.deltaMode === 0 ? 8 : 1
+        if (e.deltaX >= threshold) return Actions.switchPanel(1)
+        if (e.deltaX <= -threshold) return Actions.switchPanel(-1)
       }
     },
 


### PR DESCRIPTION
This proposed change will reduce sensitivity of panel switching when using pixel-based scrolling, such as Macbook Touchpad.

- A threshold of `8` felt comfortable for me. Not sure if we want to make this configurable.
- Kinetic scrolling (when flinging with two fingers) will cause panel to switch again. I increased the `switchPanelPause` timeout from `128` to `512` that feels natural with both touchpad and my Logitech MX 3 (line based scrolling). I can revert this if it is not wanted.