### PR TITLE
Fix drag & drop with Proton theme and custom CSS

### DIFF
--- a/src/services/styles.actions.ts
+++ b/src/services/styles.actions.ts
@@ -16,10 +16,8 @@ export function initTheme(): void {
 
   // Remove theme css
   if (Settings.reactive.theme === 'none') {
-    if (themeLinkEl) themeLinkEl.setAttribute('disabled', 'disabled')
+    themeLinkEl?.setAttribute('disabled', 'disabled')
     return
-  } else {
-    if (themeLinkEl) themeLinkEl.removeAttribute('disabled')
   }
 
   // Create next theme link
@@ -342,6 +340,8 @@ export function resetFirefoxThemeColors(): void {
 export async function loadCustomSidebarCSS(): Promise<void> {
   const stored = await browser.storage.local.get<Stored>('sidebarCSS')
   applyCustomCSS(stored.sidebarCSS)
+  // Recalculate sizes when custom CSS is changed
+  Sidebar.recalcElementSizesDebounced()
 }
 
 export async function loadCustomGroupCSS(): Promise<void> {


### PR DESCRIPTION
Custom CSS changes such as `--tabs-height` were not applied to Sidebar's element sizes when using the Proton theme.

Other themes were unaffected if their CSS was loaded before the 500 debounced call to `recalcElementSizes`. 

This change will recalculate element sizes if custom CSS is used and will not affect performance as the call is debounced.

### Changes

* Remove unnecessary .removeAttribute method call
* Recalculate element sizes when custom CSS changes