### PR TITLE
add option to ommit/shorten url in tab title attribute (hover tooltip)

### DIFF
--- a/src/_locales/dict.setup-page.ts
+++ b/src/_locales/dict.setup-page.ts
@@ -997,6 +997,21 @@ export const setupPageTranslations: Translations = {
     ru: 'Глобально',
     zh_CN: '全局',
   },
+  'settings.tabs_url_in_tooltip_full': {
+    en: 'full',
+    ru: 'settings.tabs_url_in_tooltip_full',
+    zh_CN: 'settings.tabs_url_in_tooltip_full',
+  },
+  'settings.tabs_url_in_tooltip_stripped': {
+    en: 'stripped',
+    ru: 'settings.tabs_url_in_tooltip_stripped',
+    zh_CN: 'settings.tabs_url_in_tooltip_stripped',
+  },
+  'settings.tabs_url_in_tooltip_none': {
+    en: 'none',
+    ru: 'выкл',
+    zh_CN: '无',
+  },
   'settings.activate_after_closing_no_folded': {
     en: 'Ignore folded tabs',
     ru: 'Игнорировать свернутые вкладки',
@@ -1041,6 +1056,11 @@ export const setupPageTranslations: Translations = {
     en: 'Switch panel after moving active tab to another panel',
     ru: 'Переключать панель после перемещения активной вкладки на другую панель',
     zh_CN: '将活动标签页移动到另一个面板后切换面板',
+  },
+  'settings.tabs_url_in_tooltip': {
+    en: 'Show URL in tooltip',
+    ru: 'settings.tabs_url_in_tooltip',
+    zh_CN: 'settings.tabs_url_in_tooltip',
   },
   'settings.show_new_tab_btns': {
     en: 'Show new tab buttons',

--- a/src/defaults/settings.ts
+++ b/src/defaults/settings.ts
@@ -67,6 +67,7 @@ export const DEFAULT_SETTINGS: SettingsState = {
   showNewTabBtns: true,
   newTabBarPosition: 'after_tabs',
   tabsPanelSwitchActMove: false,
+  tabsUrlInTooltip: 'full',
   openSubPanelOnMouseHover: false,
   colorizeTabs: false,
   colorizeTabsSrc: 'domain',
@@ -178,7 +179,7 @@ export const SETTINGS_OPTIONS = {
   navActBookmarksPanelLeftClickAction: ['scroll', 'none'],
   navTabsPanelMidClickAction: ['rm_act_tab', 'rm_all', 'discard', 'bookmark', 'convert', 'none'],
   navBookmarksPanelMidClickAction: ['convert', 'none'],
-
+  tabsUrlInTooltip: ['full', 'stripped', 'none'],
   groupLayout: ['grid', 'list'],
   hScrollAction: ['switch_panels', 'switch_act_tabs', 'none'],
   scrollThroughTabs: ['panel', 'global', 'none'],

--- a/src/page.setup/components/settings.tabs.vue
+++ b/src/page.setup/components/settings.tabs.vue
@@ -53,6 +53,11 @@ section(ref="el")
     label="settings.tabs_panel_switch_act_move"
     :value="Settings.reactive.tabsPanelSwitchActMove"
     @update:value="toggleTabsPanelSwitchActMove")
+  SelectField(
+    label="settings.tabs_url_in_tooltip"
+    optLabel="settings.tabs_url_in_tooltip_"
+    v-model:value="Settings.reactive.tabsUrlInTooltip"
+    :opts="Settings.getOpts('tabsUrlInTooltip')")
   ToggleField(
     label="settings.show_new_tab_btns"
     v-model:value="Settings.reactive.showNewTabBtns")

--- a/src/sidebar/components/tab.vue
+++ b/src/sidebar/components/tab.vue
@@ -100,7 +100,10 @@ const tabColor = computed<string>(() => {
 })
 const tooltip = computed((): string => {
   try {
-    return `${props.tab.title}\n${decodeURI(props.tab.url)}`
+    let str = `${props.tab.title}`
+    if (Settings.reactive.tabsUrlInTooltip == 'full') str += `\n${decodeURI(props.tab.url)}`
+    else if (Settings.reactive.tabsUrlInTooltip == 'stripped') str += `\n${decodeURI(props.tab.url).split("?")[0]}`
+    return str
   } catch (err) {
     return `${props.tab.title}\n${props.tab.url}`
   }

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -67,6 +67,7 @@ export interface SettingsState {
   showNewTabBtns: boolean
   newTabBarPosition: typeof SETTINGS_OPTIONS.newTabBarPosition[number]
   tabsPanelSwitchActMove: boolean
+  tabsUrlInTooltip: typeof SETTINGS_OPTIONS.tabsUrlInTooltip[number]
   openSubPanelOnMouseHover: boolean
   colorizeTabs: boolean
   colorizeTabsSrc: typeof SETTINGS_OPTIONS.colorizeTabsSrc[number]


### PR DESCRIPTION
as I said [here](https://github.com/mbnuqw/sidebery/issues/678) I'd like to have an option for the tab titles - not the actual text content which can be altered separetely by other addons but the title attribute within the sidebery DOM which is used for the hover tooltip.

seems to be working fine, however some translations are still missing