### PR TITLE
Fixed: Sidebars now receive storage updates via IPC, closes #694

### DIFF
--- a/src/bg/background.ts
+++ b/src/bg/background.ts
@@ -38,6 +38,8 @@ void (async function main() {
     tabsApiProxy: Tabs.tabsApiProxy,
     checkUpgrade: checkUpgrade,
     continueUpgrade: continueUpgrade,
+    registerStoreKeyChange: Store.registerRemote,
+    unregisterStoreKeyChange: Store.unregisterRemote,
   })
 
   // Init first-need stuff

--- a/src/sidebar/sidebar.ts
+++ b/src/sidebar/sidebar.ts
@@ -65,6 +65,7 @@ async function main(): Promise<void> {
     notifyAboutNewSnapshot: Snapshots.notifyAboutNewSnapshot,
     notify: Notifications.notify,
     isDropEventConsumed: DnD.isDropEventConsumed,
+    storeKeyChanged: Store.ipcKeyChanged,
   })
   IPC.setupGlobalMessageListener()
   IPC.setupConnectionListener()
@@ -97,7 +98,6 @@ async function main(): Promise<void> {
   Permissions.setupListeners()
   Windows.setupWindowsListeners()
   Containers.setupContainersListeners()
-  Store.setupStorageListeners()
   Sidebar.setupListeners()
 
   if (Settings.reactive.theme !== 'proton') Styles.initTheme()

--- a/src/types/ipc.ts
+++ b/src/types/ipc.ts
@@ -4,6 +4,7 @@ import { NormalizedSnapshot, RemovingSnapshotResult, Snapshot } from './snapshot
 import { ItemInfo, DstPlaceInfo, Notification } from '../types'
 import { IPCheckResult, UpgradingState } from '../types'
 import { GroupPageInitData, UrlPageInitData } from 'src/services/tabs.bg.actions'
+import { Stored } from './storage'
 
 export const enum InstanceType {
   unknown = -1,
@@ -44,6 +45,8 @@ export type BgActions = {
   tabsApiProxy: (method: string, ...args: any[]) => Promise<any>
   checkUpgrade: () => UpgradingState | null
   continueUpgrade: () => void
+  registerStoreKeyChange: (key: keyof Stored, destType: InstanceType, winId: ID) => void
+  unregisterStoreKeyChange: (key: keyof Stored, destType: InstanceType, winId: ID) => void
 }
 
 export type SettingsActions = {
@@ -77,6 +80,8 @@ export type SidebarActions = {
 
   notify: (config: Notification, timeout?: number) => void
   notifyAboutNewSnapshot: () => void
+
+  storeKeyChanged: <K extends keyof Stored>(key: K, newValue: Stored[K], oldValue: Stored[K]) => void
 }
 
 export type SearchPopupActions = {


### PR DESCRIPTION
This massively improves performance with many windows open, since the browser does not have to needlessly send and deserialize large objects like `tabsDataCache` and `snapshots` to all sidebars whenever that data is changed.

This PR could be extended so everything in the extension listens to these changes over IPC, but currently the only other place that watches the browser storage is the Settings page, and that's not currently wired into IPC.