### PR TITLE
Middle click on 'new tab' button to open new child tab

### DIFF
--- a/src/sidebar/components/bar.new-tab.vue
+++ b/src/sidebar/components/bar.new-tab.vue
@@ -121,6 +121,11 @@ function onNewTabMouseDown(e: MouseEvent, btn?: NewTabBtn): void {
       return
     }
 
+    if (e.altKey) {
+      reopen(btn)
+      return
+    }
+
     if (Selection.isSet() && !props.panel.selNewTab) Selection.resetSelection()
 
     Tabs.createTabInPanel(props.panel, { url: btn?.url, cookieStoreId: btn?.containerId })
@@ -130,7 +135,16 @@ function onNewTabMouseDown(e: MouseEvent, btn?: NewTabBtn): void {
   else if (e.button === 1) {
     e.preventDefault()
     Mouse.blockWheel()
-    reopen(btn)
+
+    if (e.ctrlKey) {
+      reopen(btn)
+      return
+    }
+
+    const actTab = Tabs.byId[Tabs.activeId]
+    if (actTab && !actTab.pinned && actTab.panelId === props.panel.id) {
+      Tabs.createChildTab(actTab.id, btn?.url, btn?.containerId)
+    }
   }
 
   // Right


### PR DESCRIPTION
Since `Ctrl` + Left click action on new tab bar is hard coded to perform "Open new child tab", I find it more appropriate to remap middle click action to perform "Open child tab" action as well, as it's common convention in all apps, including Firefox, that middle click should behave the same as `Ctrl` + Left click.

In order to not loose current "reopen" functionality, I remapped it to `Ctrl` + Middle click, and also as `Alt` + Left click, as it used to [behave](https://github.com/mbnuqw/sidebery/commit/7a13a06) this way before the regression.

Associated issue: https://github.com/mbnuqw/sidebery/issues/752