### PR TITLE
Add option to drag-select tabs with middle click to close

### DIFF
--- a/src/_locales/dict.setup-page.ts
+++ b/src/_locales/dict.setup-page.ts
@@ -2340,7 +2340,7 @@ export const setupPageTranslations: Translations = {
   },
   'settings.multiple_middle_close': {
     en: 'Use multi-selection when closing tabs using middle-click',
-    ru: 'Использовать множественный выбор при закрытии влкадок средней кнопкой мыши',
+    ru: 'Использовать множественный выбор при закрытии вкладок средней кнопкой мыши',
     de: 'Verwenden Sie die Mehrfachauswahl, wenn Sie Tabs mit einem Mittelklick schließen',
   },
   'settings.multiple_middle_close_note': {

--- a/src/_locales/dict.setup-page.ts
+++ b/src/_locales/dict.setup-page.ts
@@ -2338,6 +2338,16 @@ export const setupPageTranslations: Translations = {
     ru: 'Только для несистемного контекстного меню',
     de: 'Nur bei nicht-nativem Kontextmenü',
   },
+  'settings.multiple_middle_close': {
+    en: 'Use multi-selection when closing tabs using middle-click',
+    ru: 'Использовать множественный выбор при закрытии влкадок средней кнопкой мыши',
+    de: 'Verwenden Sie die Mehrfachauswahl, wenn Sie Tabs mit einem Mittelklick schließen',
+  },
+  'settings.multiple_middle_close_note': {
+    en: 'Selected tabs will be closed on releasing the button',
+    ru: 'Выбранные вкладки будут закрыты при отпускании кнопки',
+    de: 'Ausgewählte Registerkarten werden beim Loslassen der Schaltfläche geschlossen',
+  },
   'settings.long_click_delay': {
     en: 'Long click delay (ms)',
     ru: 'Задержка длительного нажатия (мс)',
@@ -3256,7 +3266,7 @@ export const setupPageTranslations: Translations = {
   },
   'styles.css_placeholder': {
     en: 'Write custom CSS here...',
-    ru: 'Write custom CSS here...',
+    ru: 'Вводите правила CSS здесь...',
     de: 'Eigenes CSS hier schreiben...',
     zh_CN: '在此处编写自定义 CSS...',
   },

--- a/src/defaults/settings.ts
+++ b/src/defaults/settings.ts
@@ -143,6 +143,7 @@ export const DEFAULT_SETTINGS: SettingsState = {
   scrollThroughTabsCyclic: false,
   scrollThroughTabsScrollArea: 0,
   autoMenuMultiSel: true,
+  multipleMiddleClose: false,
   longClickDelay: 500,
   wheelThreshold: false,
   wheelThresholdX: 10,

--- a/src/page.setup/components/settings.mouse.vue
+++ b/src/page.setup/components/settings.mouse.vue
@@ -48,6 +48,11 @@ section(ref="el")
     v-model:value="Settings.state.autoMenuMultiSel"
     :note="translate('settings.auto_menu_multi_sel_note')"
     @update:value="Settings.saveDebounced(150)")
+  ToggleField(
+    label="settings.multiple_middle_close"
+    v-model:value="Settings.state.multipleMiddleClose"
+    :note="translate('settings.multiple_middle_close_note')"
+    @update:value="Settings.saveDebounced(150)")
   NumField.-inline(
     label="settings.long_click_delay"
     unitLabel="settings.long_click_delay_"
@@ -174,7 +179,7 @@ section(ref="el")
     :opts="Settings.getOpts('tabsPanelMiddleClickAction')"
     :folded="true"
     @update:value="Settings.saveDebounced(150)")
-  
+
   .sub-title {{translate('settings.mouse.bookmarks_title')}}
   SelectField(
     label="settings.mouse.bookmarks.left_click_action"

--- a/src/sidebar/components/tab.vue
+++ b/src/sidebar/components/tab.vue
@@ -196,9 +196,14 @@ function onMouseDown(e: MouseEvent): void {
   // Middle
   else if (e.button === 1) {
     e.preventDefault()
-    Tabs.removeTabs([props.tab.id])
     Mouse.blockWheel()
-    Selection.resetSelection()
+    if (Settings.state.multipleMiddleClose) {
+      Selection.resetSelection()
+      Mouse.startMultiSelection(e, props.tab.id)
+    } else {
+      Tabs.removeTabs([props.tab.id])
+      Selection.resetSelection()
+    }
   }
 
   // Right
@@ -239,6 +244,19 @@ function onMouseUp(e: MouseEvent): void {
       }
     }
     activating = false
+  } else if (e.button === 1) {
+    if (!Settings.state.multipleMiddleClose) return;
+
+    const inMultiSelectionMode = Mouse.multiSelectionMode
+    Mouse.stopMultiSelection()
+
+    if (inMultiSelectionMode && !Settings.state.autoMenuMultiSel && Selection.getLength() > 1) {
+      return
+    }
+
+    if (!Selection.isSet()) select()
+    Tabs.removeTabs(Selection.get())
+
   } else if (e.button === 2) {
     if (e.ctrlKey || e.shiftKey) return
 

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -146,6 +146,7 @@ export interface SettingsState {
   scrollThroughTabsCyclic: boolean
   scrollThroughTabsScrollArea: number
   autoMenuMultiSel: boolean
+  multipleMiddleClose: boolean
   longClickDelay: number
   wheelThreshold: boolean
   wheelThresholdX: number


### PR DESCRIPTION
Sidebery is currently capable of drag-selecting tabs with right click, e.g. use press the button, move it upwards or downwards to select few more tabs, and then release it to open context menu for all selected tabs.

This commit adds the same functionality for middle click, in order to close multiple tabs at once.
New options sits in `Sidebery settings` > `Mouse` > `Use multi-selection when closing tabs using middle-click`, and is disabled by default.

![middle-click-drag-select](https://user-images.githubusercontent.com/37851576/189430167-a5f28b17-6666-4226-a5c8-f7baae07d579.gif)

