### PR TITLE
Create a "hide group tabs"

### DIFF
--- a/src/_locales/dict.setup-page.ts
+++ b/src/_locales/dict.setup-page.ts
@@ -507,6 +507,12 @@ export const setupPageTranslations: Translations = {
     de: 'Native Scrollleiste verwenden',
     zh_CN: '使用原生滚动条',
   },
+  'settings.hide_group_tabs': {
+    en: 'Hide group tabs of collapsed tabs',
+    ru: '',
+    de: '',
+    zh_CN: '',
+  },
   'settings.native_scrollbars_thin': {
     en: 'Use thin scroll-bars',
     ru: 'Использовать узкие скроллбары',

--- a/src/defaults/settings.ts
+++ b/src/defaults/settings.ts
@@ -89,6 +89,7 @@ export const DEFAULT_SETTINGS: SettingsState = {
   groupOnOpen: true,
   tabsTreeLimit: 'none',
   hideFoldedTabs: false,
+  hideGroupTabs: false,
   autoFoldTabs: false,
   autoFoldTabsExcept: 'none',
   autoExpandTabs: false,

--- a/src/page.setup/components/settings.tabs-tree.vue
+++ b/src/page.setup/components/settings.tabs-tree.vue
@@ -22,6 +22,12 @@ section(ref="el")
     :inactive="!Settings.state.tabsTree"
     :value="Settings.state.hideFoldedTabs"
     @update:value="toggleHideFoldedTabs")
+  .sub-fields
+    ToggleField(
+      label="settings.hide_group_tabs"
+      v-model:value="Settings.state.hideGroupTabs"
+      :inactive="!Settings.state.hideFoldedTabs"
+      @update:value="Settings.saveDebounced(150)")
   ToggleField(
     label="settings.auto_fold_tabs"
     :inactive="!Settings.state.tabsTree"

--- a/src/sidebar/components/tab.vue
+++ b/src/sidebar/components/tab.vue
@@ -427,8 +427,14 @@ function activate(): void {
   }
 
   if (props.tab.id !== Tabs.activeId) {
+    const tab = Tabs.byId[Tabs.activeId]
     activating = true
     browser.tabs.update(props.tab.id, { active: true })
+    if(tab && tab.folded && Settings.state.hideFoldedTabs && Settings.state.hideGroupTabs) {
+      browser.tabs.hide?.(tab.id).catch(err => {
+        Logs.err('Deslecting tab, cannot hide group tab:', err)
+      })
+    }
   }
 }
 


### PR DESCRIPTION
The hide groups option will hide group tabs when the group is folded and not selected.

Useful for windows that have a lot of tab groups, as the tab group pages tend to clutter the the tabs bar.