### PR TITLE
Add information for workaround. Relates to #660

### DIFF
--- a/src/_locales/dict.setup-page.ts
+++ b/src/_locales/dict.setup-page.ts
@@ -78,7 +78,7 @@ export const setupPageTranslations: Translations = {
     zh_CN: '无',
   },
   'container.rules_include': {
-    en: 'Include URLs',
+    en: 'Include URLs. Requires "Blocking web request" and "Proxy" permissions to work currently',
     ru: 'Включать вкладки',
     de: 'URLs einschließen',
     zh_CN: 'URL列表',

--- a/src/_locales/dict.setup-page.ts
+++ b/src/_locales/dict.setup-page.ts
@@ -80,7 +80,7 @@ export const setupPageTranslations: Translations = {
   'container.rules_include': {
     en: 'Include URLs. Requires "Blocking web request" and "Proxy" permissions to work currently',
     ru: 'Включать вкладки',
-    de: 'URLs einschließen',
+    de: 'URLs einschließen. Benötigt aktuell noch "Blocking web requests" und "Proxy" Berechtigung.',
     zh_CN: 'URL列表',
   },
   'container.rules_include_tooltip': {


### PR DESCRIPTION
I do not know much about Firefox addons, but this info would have helped me a lot. This does not fix the missing permissions workflow in #660 but it guides the user.