### PR TITLE
Fixed: Switched panel,  Tabs.activeId not update.

### DIFF
--- a/src/services/tabs.fg.actions.ts
+++ b/src/services/tabs.fg.actions.ts
@@ -1336,6 +1336,7 @@ export function activateLastActiveTabOf(panelId: ID): void {
   if (!tab || tab.panelId !== p.id) tab = panelTabs[0]
   if (tab && tab.discarded) tab = panelTabs.find(t => !t.discarded)
   if (tab) {
+    Tabs.activeId = tab.id
     browser.tabs.update(tab.id, { active: true }).catch(err => {
       Logs.err('Tabs.activateLastActiveTabOf: Cannot activate tab:', err)
     })


### PR DESCRIPTION
```
function onMouseUp(e: MouseEvent): void {
  ...
  if (
    Settings.state.tabsSecondClickActPrev &&
    // result = true,  first switch panel then click tab. will jump back prev panel tab.   
    props.tab.id === Tabs.activeId &&
    withoutMods &&
    !activating
  ) {
    const history = Tabs.getActiveTabsHistory()
    const prevTabId = history.actTabs[history.actTabs.length - 1]
    if (prevTabId !== undefined) browser.tabs.update(prevTabId, { active: true })
  }
  ...
}
```
