### PR TITLE
Add option to show titles of globally-top pinned tabs

### DIFF
--- a/src/page.setup/components/settings.tabs.vue
+++ b/src/page.setup/components/settings.tabs.vue
@@ -176,7 +176,7 @@ section(ref="el")
     @update:value="Settings.saveDebounced(150)")
   ToggleField(
     label="settings.pinned_tabs_list"
-    :inactive="Settings.state.pinnedTabsPosition !== 'panel'"
+    :inactive="Settings.state.pinnedTabsPosition !== 'panel' && Settings.state.pinnedTabsPosition!== 'top'"
     v-model:value="Settings.state.pinnedTabsList"
     @update:value="Settings.saveDebounced(150)")
 

--- a/src/sidebar/components/tab.vue
+++ b/src/sidebar/components/tab.vue
@@ -118,7 +118,10 @@ const favPlaceholder = computed((): string => {
 })
 const isPinned = computed<boolean>(() => {
   if (!props.tab.pinned) return false
-  if (Settings.state.pinnedTabsList && Settings.state.pinnedTabsPosition === 'panel') {
+  if (
+    Settings.state.pinnedTabsList &&
+    (Settings.state.pinnedTabsPosition === 'panel' || Settings.state.pinnedTabsPosition === 'top')
+  ) {
     return false
   }
   return true

--- a/src/styles/themes/proton/sidebar/bar.pinned-tabs.styl
+++ b/src/styles/themes/proton/sidebar/bar.pinned-tabs.styl
@@ -58,6 +58,10 @@
   grid-gap: var(--tabs-margin)
   padding: 0 var(--tabs-margin) var(--tabs-margin)
 
+#root[data-pinned-tabs-position="top"][data-pinned-tabs-list="true"] .PinnedTabsBar
+  padding: 0 0 calc(var(--tabs-margin) + 9px)
+  grid-gap: 0
+
 // ---
 // -- Separator
 // -
@@ -73,6 +77,9 @@
   background-image: linear-gradient(90deg, transparent, var(--frame-fg) 10%, var(--frame-fg) 90%, transparent)
 
 #root[data-pinned-tabs-position="panel"][data-pinned-tabs-list="true"] .PinnedTabsBar:after
+  display: block
+
+#root[data-pinned-tabs-position="top"][data-pinned-tabs-list="true"] .PinnedTabsBar:after
   display: block
 
 // ---
@@ -104,8 +111,11 @@
     display: block
 
 #root[data-pinned-tabs-position="panel"][data-pinned-tabs-list="true"] .PinnedTabsBar .tab-wrapper
+#root[data-pinned-tabs-position="top"][data-pinned-tabs-list="true"] .PinnedTabsBar .tab-wrapper
   width: 100%
+
 #root[data-pinned-tabs-position="panel"][data-pinned-tabs-list="true"] .PinnedTabsBar .tab-wrapper:after
+#root[data-pinned-tabs-position="top"][data-pinned-tabs-list="true"] .PinnedTabsBar .tab-wrapper:after
   top: 0
   left: 0
   width: 100%
@@ -141,6 +151,7 @@
     height: var(--tabs-pinned-height)
 
 #root[data-pinned-tabs-position="panel"][data-pinned-tabs-list="true"] .PinnedTabsBar .to-the-end
+#root[data-pinned-tabs-position="top"][data-pinned-tabs-list="true"] .PinnedTabsBar .to-the-end
   width: 100%
   &:before
     top: 0

--- a/src/styles/themes/proton/sidebar/sidebar.styl
+++ b/src/styles/themes/proton/sidebar/sidebar.styl
@@ -105,6 +105,7 @@ body
   height: 100%
   flex-grow: 1
   flex-shrink: 1
+  overflow: hidden
 // If .main-box is the first element, set margin top
 .Notifications + .main-box .central-box
   height: calc(100% + var(--s-darker-border-width, 0px) - var(--general-margin))


### PR DESCRIPTION
The option was only available for `in panel - top` position. Now it has the same style in form of list rather than grid when `Show titles of pinned tabs` is on. 