### PR TITLE
Support middle-click on history items

### DIFF
--- a/src/services/history.actions.ts
+++ b/src/services/history.actions.ts
@@ -206,7 +206,7 @@ export function scrollToHistoryItem(id: string): void {
   if (el) el.scrollIntoView({ behavior: 'smooth', block: 'nearest' })
 }
 
-export async function openTab(item: HistoryItem): Promise<void> {
+export async function openTab(item: HistoryItem, activate?: boolean): Promise<void> {
   let panel: Panel | undefined = Sidebar.reactive.panelsById[Sidebar.lastTabsPanelId]
   if (!Utils.isTabsPanel(panel)) {
     const activeTab = Tabs.byId[Tabs.activeId]
@@ -214,7 +214,7 @@ export async function openTab(item: HistoryItem): Promise<void> {
     else panel = Sidebar.reactive.panels.find(p => Utils.isTabsPanel(p))
   }
 
-  const tabInfo: ItemInfo = { id: 0, url: item.url, title: item.title, active: true }
+  const tabInfo: ItemInfo = { id: 0, url: item.url, title: item.title, active: activate }
   const dstInfo: DstPlaceInfo = { windowId: Windows.id, discarded: false }
   if (Utils.isTabsPanel(panel)) {
     dstInfo.panelId = panel.id

--- a/src/sidebar/components/history-item.vue
+++ b/src/sidebar/components/history-item.vue
@@ -24,6 +24,7 @@ import { Selection } from 'src/services/selection'
 import { Settings } from 'src/services/settings'
 import { Search } from 'src/services/search'
 import { History } from 'src/services/history'
+import { Bookmarks } from 'src/services/bookmarks'
 
 const props = defineProps<{ item: HistoryItem }>()
 
@@ -61,13 +62,14 @@ function onMouseUp(e: MouseEvent): void {
   Mouse.stopLongClick()
   if (!sameTarget) return
 
-  if (e.button === 0) {
-    if (Search.reactive.rawValue) {
+  if (e.button === 0 || e.button === 1) {
+    let { dst, activateFirstTab: activateNewTab } = Bookmarks.getMouseOpeningConf(e.button)
+    // Reset search input, if navigating away from the history panel
+    if (Search.reactive.rawValue && activateNewTab) {
       Search.stop()
       Selection.resetSelection()
     }
-
-    History.openTab(props.item)
+    History.openTab(props.item, activateNewTab)
   }
 
   if (e.button === 2) {


### PR DESCRIPTION
This PR adds some basic support for middle-clicking on links in the history panel.

If the user has the setting "Mouse > Bookmarks actions > Middle-click on the bookmark" set to "open in new tab", so that middle-clicking a bookmark opens it in a new tab without navigating away from the bookmarks panel or resetting the search input, then middle-click will behave the same way in the bookmarks panel.

As referenced:

- Here: https://github.com/mbnuqw/sidebery/issues/780#issuecomment-1263307157, and
- Here: https://github.com/mbnuqw/sidebery/issues/665,

...middle-clicking these items currently does nothing.

Ideally the extension would support a range of mouse settings for the history panel, as it does for the bookmarks panel. I've not implemented that here though. Seems to me that a user would rarely want the on-click behavior of history items to be different to that of bookmarks, so the approach here is just to pull from the bookmarks' settings.