### PR TITLE
Add "Create new tab" option for single left click on tabs panel

### DIFF
--- a/src/defaults/settings.ts
+++ b/src/defaults/settings.ts
@@ -228,7 +228,7 @@ export const SETTINGS_OPTIONS = {
   tabLongRightClick: ['reload', 'duplicate', 'pin', 'mute', 'clear_cookies', 'new_after',
     'new_child', 'edit_title', 'none'],
   tabCloseMiddleClick: ['close', 'discard'],
-  tabsPanelLeftClickAction: ['prev', 'expand', 'parent', 'none'],
+  tabsPanelLeftClickAction: ['prev', 'expand', 'parent', 'tab', 'none'],
   tabsPanelDoubleClickAction: ['collapse', 'tab', 'undo', 'none'],
   tabsPanelRightClickAction: ['next', 'expand', 'parent', 'menu', 'none'],
   tabsPanelMiddleClickAction: ['rm_act_tab', 'tab', 'undo', 'none'],

--- a/src/sidebar/components/panel.tabs.vue
+++ b/src/sidebar/components/panel.tabs.vue
@@ -104,6 +104,7 @@ function onMouseDown(e: MouseEvent): void {
       if (!targetTab) return
       return Tabs.toggleBranch(targetTab.id)
     }
+    if (la === 'tab') return Tabs.createTabInPanel(props.panel)
     if (la === 'parent') {
       if (!Settings.state.tabsTree) return
       const activeTab = Tabs.list.find(t => t.active)


### PR DESCRIPTION
This PR adds new option for single left click on tabs panel — "Create new tab", which allows user to use it instead of double clicking if they want to. When "new tab" button is disabled in settings, it basically allows to use the whole free space on bottom as a big new tab button.