### PR TITLE
Add favicon for about:debugging

### DIFF
--- a/src/assets/developer.svg
+++ b/src/assets/developer.svg
@@ -1,0 +1,6 @@
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+  <path fill="context-fill" fill-opacity="context-fill-opacity" d="M14.555 3.2l-2.434 2.436a1.243 1.243 0 1 1-1.757-1.757L12.8 1.445A3.956 3.956 0 0 0 11 1a3.976 3.976 0 0 0-3.434 6.02l-6.273 6.273a1 1 0 1 0 1.414 1.414L8.98 8.434A3.96 3.96 0 0 0 11 9a4 4 0 0 0 4-4 3.956 3.956 0 0 0-.445-1.8z"/>
+</svg>

--- a/src/assets/developer.svg
+++ b/src/assets/developer.svg
@@ -1,6 +1,1 @@
-<!-- This Source Code Form is subject to the terms of the Mozilla Public
-   - License, v. 2.0. If a copy of the MPL was not distributed with this
-   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
-<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
-  <path fill="context-fill" fill-opacity="context-fill-opacity" d="M14.555 3.2l-2.434 2.436a1.243 1.243 0 1 1-1.757-1.757L12.8 1.445A3.956 3.956 0 0 0 11 1a3.976 3.976 0 0 0-3.434 6.02l-6.273 6.273a1 1 0 1 0 1.414 1.414L8.98 8.434A3.96 3.96 0 0 0 11 9a4 4 0 0 0 4-4 3.956 3.956 0 0 0-.445-1.8z"/>
-</svg>
+<svg id="icon_dev" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><path fill="context-fill" fill-opacity="context-fill-opacity" d="M14.555 3.2l-2.434 2.436a1.243 1.243 0 1 1-1.757-1.757L12.8 1.445A3.956 3.956 0 0 0 11 1a3.976 3.976 0 0 0-3.434 6.02l-6.273 6.273a1 1 0 1 0 1.414 1.414L8.98 8.434A3.96 3.96 0 0 0 11 9a4 4 0 0 0 4-4 3.956 3.956 0 0 0-.445-1.8z"/></svg>

--- a/src/page.group/group.html
+++ b/src/page.group/group.html
@@ -47,6 +47,7 @@
     <inject>svg://src/assets/favicon-addons.svg#icon_addons</inject>
     <inject>svg://src/assets/favicon-perf.svg#icon_perf</inject>
     <inject>svg://src/assets/favicon-link.svg#icon_link_favicon</inject>
+    <inject>svg://src/assets/developer.svg#icon_dev</inject>
   </div>
 
   <input type="text" id="title" class="title" value="Group" placeholder="---">

--- a/src/page.setup/setup.html
+++ b/src/page.setup/setup.html
@@ -87,6 +87,7 @@
     <inject>svg://src/assets/plus.svg#icon_plus</inject>
     <inject>svg://src/assets/reload.svg#icon_reload</inject>
     <inject>svg://src/assets/sel-all.svg#icon_sel_all</inject>
+    <inject>svg://src/assets/developer.svg#icon_dev</inject>
   </div>
 </body>
 </html>

--- a/src/services/favicons.actions.ts
+++ b/src/services/favicons.actions.ts
@@ -371,6 +371,7 @@ export function getFavPlaceholder(url: string): string {
     if (url.startsWith('about:dev')) return '#icon_code'
     if (url.startsWith('about:proc')) return '#icon_perf'
     if (url.startsWith('about:prot')) return '#icon_dashboard'
+    if (url.startsWith('about:debug')) return '#icon_dev'
   }
 
   return '#icon_ff'

--- a/src/sidebar/sidebar.html
+++ b/src/sidebar/sidebar.html
@@ -176,6 +176,7 @@
     <inject>svg://src/assets/url-conf.svg#icon_url_conf</inject>
     <inject>svg://src/assets/hide.svg#icon_hide</inject>
     <inject>svg://src/assets/sel-all.svg#icon_sel_all</inject>
+    <inject>svg://src/assets/developer.svg#icon_dev</inject>
   </div>
 </body>
 


### PR DESCRIPTION
This PR adds favicon for about:debugging page. It uses a copy of Firefox's built-in `developer` icon: 
[chrome://global/skin/icons/developer.svg](chrome://global/skin/icons/developer.svg)

_Before_: 
![image](https://github.com/mbnuqw/sidebery/assets/37851576/d95b4022-8b57-4f33-92ab-336d3165ec6a)

_After_:
![2023-07-17_07-03](https://github.com/mbnuqw/sidebery/assets/37851576/b0ff99f5-eca7-4121-b848-9bf38399fde2)
