### PR TITLE
Add container sorting to bookmark, new tab, reopen, settings menus

### DIFF
--- a/src/page.setup/components/settings.containers.vue
+++ b/src/page.setup/components/settings.containers.vue
@@ -3,7 +3,7 @@ section(ref="el")
   h2 {{translate('settings.containers_title')}}
   span.header-shadow
   .card(
-    v-for="(container, id) in Containers.reactive.byId"
+    v-for="(container, id) in Containers.sortContainers(Object.values(Containers.reactive.byId))"
     :key="container.id"
     :data-color="container.color")
     .card-body(@click="SetupPage.reactive.selectedContainer = container")

--- a/src/services/containers.actions.ts
+++ b/src/services/containers.actions.ts
@@ -298,3 +298,9 @@ export function getContainerFor(url: string): string | undefined {
 
   return
 }
+
+export function sortContainers(containers: Container[]): Container[] {
+  return containers.sort(function(a, b) {
+    return a.name.localeCompare(b.name)
+  })
+}

--- a/src/services/menu.options.bookmarks.ts
+++ b/src/services/menu.options.bookmarks.ts
@@ -102,7 +102,7 @@ export const bookmarksMenuOptions: Record<string, () => MenuOption | MenuOption[
 
     if (!Windows.incognito) {
       const ignoreRules = Menu.ctxMenuIgnoreContainersRules
-      for (const c of Object.values(Containers.reactive.byId)) {
+      for (const c of Containers.sortContainers(Object.values(Containers.reactive.byId))) {
         if (ignoreRules?.[c.id]) continue
         opts.push({
           label: translate('menu.bookmark.open_in_') + c.name,

--- a/src/services/menu.options.tabs.ts
+++ b/src/services/menu.options.tabs.ts
@@ -167,7 +167,7 @@ export const tabsMenuOptions: Record<string, () => MenuOption | MenuOption[] | u
       })
     }
 
-    for (const c of Object.values(Containers.reactive.byId)) {
+    for (const c of Containers.sortContainers(Object.values(Containers.reactive.byId))) {
       if (firstTab.cookieStoreId === c.id) continue
       if (ignoreRules?.[c.id]) continue
       opts.push({
@@ -227,7 +227,7 @@ export const tabsMenuOptions: Record<string, () => MenuOption | MenuOption[] | u
       })
     }
 
-    for (const c of Object.values(Containers.reactive.byId)) {
+    for (const c of Containers.sortContainers(Object.values(Containers.reactive.byId))) {
       if (firstTab.cookieStoreId === c.id) continue
       if (ignoreRules?.[c.id]) continue
       opts.push({

--- a/src/services/menu.options.ts
+++ b/src/services/menu.options.ts
@@ -121,7 +121,7 @@ export const menuOptions: Record<string, () => MenuOption | MenuOption[] | undef
     const opts: MenuOption[] = []
     const ignoreRules = Menu.ctxMenuIgnoreContainersRules
 
-    for (const c of Object.values(Containers.reactive.byId)) {
+    for (const c of Containers.sortContainers(Object.values(Containers.reactive.byId))) {
       if (ignoreRules?.[c.id]) continue
       opts.push({
         label: c.name,


### PR DESCRIPTION
See https://github.com/mbnuqw/sidebery/issues/354 for impetus.

## Context
When opening a new tab, reopening a tab in a container, opening a bookmark in a container, or viewing available containers in Sidebery settings, they currently are displayed in the order of creation rather than alphabetically. 

This changeset introduces a sorting function (`sortContainers`) into the Container Actions file for reusability, and uses that sorting function for those aforementioned context menus and settings menus. I chose to use [`localCompare`](https://www.w3schools.com/jsref/jsref_localecompare.asp) to allow for cross language sorting based on browser settings.

Please note that I haven't worked in TypeScript in a long while and wasn't very familiar with it to begin with, so if there are better ways of doing these things, please let me know :)

## Testing
I followed the steps in the [Contributing Guide](https://github.com/mbnuqw/sidebery/blob/aad7e28c055343e22fdaf6346a4dda5136a271ae/CONTRIBUTING.md#L4) and tested locally, making sure containers were sorted in the new tab, reopen in, open bookmark in, and settings menus.

Before, reopen in menu:
![Screen Shot 2023-07-26 at 12 32 45](https://github.com/mbnuqw/sidebery/assets/5409133/1426163b-bbd9-444f-82b1-3a989f2c6c1f)

After, reopen in menu:
![Screen Shot 2023-07-26 at 12 36 18](https://github.com/mbnuqw/sidebery/assets/5409133/fbdbb37e-7ddb-4a8d-93b3-fb8a8038e245)
