### PR TITLE
Implement tabs warmup functionality

### DIFF
--- a/src/_locales/dict.setup-page.ts
+++ b/src/_locales/dict.setup-page.ts
@@ -1783,6 +1783,11 @@ Examples: "*", "ctrl+$", "ctrl+alt+g"`,
     de: 'Unten',
     zh_CN: '底部',
     zh_TW: '底部',
+  },  
+  'settings.tab_warmup_on_hover': {
+    en: 'Preload tab contents on mouse hover (tab warmup)',
+    ru: 'Предварительная прогрузка вкладки при наведении мыши',
+    de: 'Tab-Inhalte beim Bewegen der Maus vorladen (Tab-Aufwärmen)',
   },
   'settings.select_active_tab_first': {
     en: 'Select the active tab first',

--- a/src/defaults/settings.ts
+++ b/src/defaults/settings.ts
@@ -82,6 +82,7 @@ export const DEFAULT_SETTINGS: SettingsState = {
   tabsPanelSwitchActMoveAuto: true,
   tabsUrlInTooltip: 'full',
   newTabCtxReopen: false,
+  tabWarmupOnHover: false,
 
   // New tab position
   moveNewTabPin: 'start',

--- a/src/page.setup/components/settings.tabs.vue
+++ b/src/page.setup/components/settings.tabs.vue
@@ -115,6 +115,10 @@ section(ref="el")
       :inactive="!Settings.state.showNewTabBtns"
       :opts="Settings.getOpts('newTabBarPosition')"
       @update:value="Settings.saveDebounced(150)")
+  ToggleField(
+    label="settings.tab_warmup_on_hover"
+    v-model:value="Settings.state.tabWarmupOnHover"
+    @update:value="Settings.saveDebounced(150)")
 
   .wrapper
     .sub-title: .text {{translate('settings.new_tab_position')}}

--- a/src/sidebar/components/tab.vue
+++ b/src/sidebar/components/tab.vue
@@ -25,6 +25,7 @@
   @contextmenu.stop="onCtxMenu"
   @mousedown.stop="onMouseDown"
   @mouseup.stop="onMouseUp"
+  @mouseenter.stop="onMouseEnter"
   @dblclick.prevent.stop="onDoubleClick")
   .dnd-layer(data-dnd-type="tab" :data-dnd-id="tab.id")
   .body
@@ -379,6 +380,10 @@ function onDragStart(e: DragEvent): void {
     if (dragImgEl) e.dataTransfer.setDragImage(dragImgEl, -3, -3)
     e.dataTransfer.effectAllowed = 'copyMove'
   }
+}
+
+function onMouseEnter(e: MouseEvent){
+  browser.tabs.warmup(tab.id)
 }
 
 function onAudioMouseDown(e: MouseEvent, tab: Tab): void {

--- a/src/sidebar/components/tab.vue
+++ b/src/sidebar/components/tab.vue
@@ -383,7 +383,7 @@ function onDragStart(e: DragEvent): void {
 }
 
 function onMouseEnter(e: MouseEvent){
-  browser.tabs.warmup(tab.id)
+  if (Settings.state.tabWarmupOnHover) browser.tabs.warmup(tab.id)
 }
 
 function onAudioMouseDown(e: MouseEvent, tab: Tab): void {

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -81,6 +81,7 @@ export interface SettingsState {
   tabsPanelSwitchActMoveAuto: boolean
   tabsUrlInTooltip: (typeof SETTINGS_OPTIONS.tabsUrlInTooltip)[number]
   newTabCtxReopen: boolean
+  tabWarmupOnHover: boolean
 
   // New tab position
   moveNewTabPin: (typeof SETTINGS_OPTIONS.moveNewTabPin)[number]


### PR DESCRIPTION
After digging in Firefox source code for a while, I found out that it by default [does something](https://searchfox.org/mozilla-central/source/browser/base/content/tabbrowser-tab.js#542) called "tab warmup" — when user hovers the tab, it kind of preloads it's contents, to make the switch feel faster if user decides to click on it. 

Here's the [Firefox Source Docs](https://firefox-source-docs.mozilla.org/browser/base/tabbrowser/async-tab-switcher.html#async-tab-switcher-warming) article with more explanation on this feature. Few words from it:  

> 
> Tab warming allows the browser to proactively render and upload layers to the compositor for tabs that the user is likely to switch to. The simplest example is when a user’s mouse cursor is hovering over a tab. When this occurs, the async tab switcher is told to put that tab into a warming list, and to set its state to STATE_LOADING, even though the user hasn’t yet clicked on it.
> 
> Warming a tab queues up a timer to unload background tabs (if no such timer already exists), which will clear out the warmed tab if the user doesn’t eventually click on it. The unload will occur even if the user continues to hover the tab.


Sidebery doesn't do such warmup, which I checked by setting `browser.tabs.remote.logSwitchTiming` flag in `about:configs` and hovering over Sidebery tabs. And default tabs panel prints various warmup logs in browser console on hovering tabs. 

This PR adds the same functionality in Sidebery using [browser.tabs.warmup](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/tabs/warmup) method, and an option to toggle it in settings. Default value is `false` just in case — but probably could be `true`, as native tab panel does it by default.
