### PR TITLE
Ignore single left click on tabs panel when context menu is open

### DIFF
--- a/src/sidebar/components/panel.tabs.vue
+++ b/src/sidebar/components/panel.tabs.vue
@@ -80,6 +80,11 @@ function onMouseDown(e: MouseEvent): void {
   if (Selection.isSet()) return
 
   if (e.button === 0) {
+    if (Menu.isOpen) {
+      Menu.close()
+      if (!Settings.state.ctxMenuNative) return
+    }
+
     const la = Settings.state.tabsPanelLeftClickAction
     if (la === 'prev') return Sidebar.switchPanel(-1)
     if (la === 'expand') {

--- a/src/sidebar/components/panel.tabs.vue
+++ b/src/sidebar/components/panel.tabs.vue
@@ -82,7 +82,7 @@ function onMouseDown(e: MouseEvent): void {
   if (e.button === 0) {
     if (Menu.isOpen) {
       Menu.close()
-      if (!Settings.state.ctxMenuNative) return
+      return
     }
 
     const la = Settings.state.tabsPanelLeftClickAction

--- a/src/sidebar/components/tab.vue
+++ b/src/sidebar/components/tab.vue
@@ -124,7 +124,7 @@ function onMouseDownClose(e: MouseEvent): void {
   Mouse.setTarget('tab.close', tab.id)
   if (Menu.isOpen) {
     Menu.close()
-    if (!Settings.state.ctxMenuNative) return
+    return
   }
   if (Tabs.editableTabId === tab.id) {
     tab.reactive.customTitle = tab.title
@@ -154,7 +154,7 @@ function onMouseDown(e: MouseEvent): void {
 
   if (Menu.isOpen) {
     Menu.close()
-    if (!Settings.state.ctxMenuNative && e.button === 0) return
+    if (e.button === 0) return
   }
   if (tab.reactive.customTitleEdit) return
 


### PR DESCRIPTION
This PR applies [this patch](https://github.com/mbnuqw/sidebery/commit/9eb70ac5327429f55ecd16e88e36359832175261) for single left click on tabs panel as well. 

It also removes the check for native context menu. The problem, which original patch (as per my understanding) tries to solve, happens to me with native context menu enabled as well — when I have context menu open and perform left click outside in order to close it, the click event gets passed to the Sidebery element under cursor. It happens to me on Windows 11 with "Native context menu" option enabled. And it doesn't happen without the "native menu" check — I think it's not needed anyway, as in the case when left click gets consumed by native context menu's overlay or backdrop (and such context menu gets closed), Sidebery should not receive this event anyway.