### PR TITLE
Warmup successor tab on hovering active tab

### DIFF
--- a/src/services/tabs.fg.actions.ts
+++ b/src/services/tabs.fg.actions.ts
@@ -2562,6 +2562,7 @@ function updateSuccession(exclude?: ID[]) {
       browser.tabs.moveInSuccession([activeTab.id], target.id).catch(err => {
         Logs.err('Tabs.updateSuccession: Cannot update succession:', err)
       })
+      activeTab.successorTabId = target.id
       return target
     }
   }

--- a/src/sidebar/components/tab.vue
+++ b/src/sidebar/components/tab.vue
@@ -416,8 +416,15 @@ function onDragStart(e: DragEvent): void {
 }
 
 function onMouseEnter(e: MouseEvent) {
-  if (Settings.state.tabWarmupOnHover && !tab.active) {
-    browser.tabs.warmup(tab.id)
+  if (Settings.state.tabWarmupOnHover) {
+     if (tab.active) {
+        /// warmup successor tab, in case user decides to close active tab
+        const successorTabId = tab.successorTabId;
+        if (successorTabId && successorTabId > -1) browser.tabs.warmup(successorTabId)
+    } else {
+      /// warmup hovered tab
+      browser.tabs.warmup(tab.id);
+    }
   }
 }
 

--- a/src/sidebar/components/tab.vue
+++ b/src/sidebar/components/tab.vue
@@ -417,7 +417,7 @@ function onDragStart(e: DragEvent): void {
 
 function onMouseEnter(e: MouseEvent) {
   if (Settings.state.tabWarmupOnHover) {
-     if (tab.active) {
+    if (tab.active) {
         /// warmup successor tab, in case user decides to close active tab
         const successorTabId = tab.successorTabId;
         if (successorTabId && successorTabId > -1) browser.tabs.warmup(successorTabId)


### PR DESCRIPTION
I guess it should be better than not doing anything on hovering active tab? This way we lazily store the `successorTabId` in case it's get updated in other places such as `Tabs.removeTabs()` method, and can use this value to warmup the tab that's going to be activated if user closes current tab (either via middle click or close button). 

It seems to me to work better than previously suggested `Tabs.findSuccessorTab(tab)` method call – and it could probably cover even the "flipTab" one when user have a setting to activate previously active tab on close (as it should become the successor tab as well). What do you think?