### PR TITLE
Don't reopen during POSTs.

### DIFF
--- a/src/services/web-req.fg.ts
+++ b/src/services/web-req.fg.ts
@@ -24,6 +24,10 @@ function onBeforeRequestHandler(info: browser.webRequest.ReqDetails): optBlockin
       const dst = { panelId: tab.panelId, containerId: tab.reopenInContainer }
       const item = { id: tab.id, url: info.url, active: tab.active, index: tab.index }
       delete tab.reopenInContainer
+      if (info.method == "POST") {
+        Logs.warn("onBeforeRequestHandler not reopening, POST.")
+        return {}
+      }
       Tabs.reopen([item], dst)
       return { cancel: true }
     }


### PR DESCRIPTION
This can happen, for example, when something loads a file:// URL, that then has static form data and javascript to immediately submit it.

We then turn the POST with data in the default container into a GET with no data in the target container.

That doesn't work very well.

As such, let's just refuse to reopen a tab in a new container during a POST, we can't bring the data with us (that I've figured out how to do anyhow).

This was the actual problem that had me originally open #1200 .