### PR TITLE
Better shortcuts

### DIFF
--- a/src/page.setup/components/keybindings.keybinding.vue
+++ b/src/page.setup/components/keybindings.keybinding.vue
@@ -53,7 +53,7 @@ function changeKeybinding(cmd: Command): void {
 
 function normalizeShortcut(s?: string): string {
   if (!s) return '---'
-  if (Info.reactive.os === 'mac') return s.replace('Command', '⌘').replace('MacCtrl', 'Ctrl')
+  if (Info.reactive.os === 'mac') return s.replace('Command', '⌘').replace('MacCtrl', '⌃')
   if (Info.reactive.os === 'win') return s.replace('Command', 'Win')
   if (Info.reactive.os === 'linux') return s.replace('Command', 'Super')
   return s

--- a/src/services/keybindings.actions.ts
+++ b/src/services/keybindings.actions.ts
@@ -19,7 +19,7 @@ import * as Logs from 'src/services/logs'
 import { SetupPage } from './setup-page'
 
 const VALID_SHORTCUT =
-  /^((Ctrl|Alt|Command|MacCtrl)\+)((Shift|Alt)\+)?([A-Z0-9]|Comma|Period|Home|End|PageUp|PageDown|Space|Insert|Delete|Up|Down|Left|Right|F\d\d?)$|^((Ctrl|Alt|Command|MacCtrl)\+)?((Shift|Alt)\+)?(F\d\d?)$/
+  /^((Ctrl|Alt|Command|MacCtrl)\+)((Shift|Alt|Ctrl|Command|MacCtrl)\+)?([A-Z0-9]|Comma|Period|Home|End|PageUp|PageDown|Space|Insert|Delete|Up|Down|Left|Right|F\d\d?)$|^((Ctrl|Alt|Command|MacCtrl)\+)?((Shift|Alt|Ctrl|Command|MacCtrl)\+)?(F\d\d?)$/
 
 /**
  * Load keybindings


### PR DESCRIPTION
Currently, the mozilla documentation states that for secondary modifiers:
    
> If supplied, this must be either "Shift" or (for Firefox ≥ 63) any one of "Ctrl", "Alt", "Command", or "MacCtrl". Must not be the modifier already used as the main modifier.
    
This commit adds Ctrl, Command, and MacCtrl to the list of allowed secondary modifiers, allowing stuff like MacCtrl+Ctrl+Period as a binding.
    
Of course, that renders quite confusingly (Ctrl+Ctrl+Period), so I did a second change to render MacCtrl as ⌃, which is UTF 2302 Up Arrowhead.  This appears to be what MacOS is using to render it.

At the very least, it's the symbol they use on their website for it. :)

This gives us ⌃+Ctrl+Period, which is at least less confusing, even if I wish that Command came through as Command.