### PR TITLE
Fix search with about:blank tabs.

### DIFF
--- a/src/services/search.actions.ts
+++ b/src/services/search.actions.ts
@@ -385,6 +385,9 @@ export function stop(): void {
 }
 
 export function check(str: string): boolean {
+  if (str === undefined) {
+    return false
+  }
   str = str.toLowerCase()
   return str.includes(query)
 }


### PR DESCRIPTION
Currently, search fails if a panel has any tabs which are open to about:blank.

This check fixes the issue, allowing search to work.