### PR TITLE
Confirm popup by pressing the enter key

### DIFF
--- a/src/sidebar/sidebar.vue
+++ b/src/sidebar/sidebar.vue
@@ -282,6 +282,12 @@ function onDocumentKeyup(e: KeyboardEvent): void {
     // Sub-panel
     if (Sidebar.subPanelActive) Sidebar.closeSubPanel()
   }
+
+  // Confirm popups
+  if (e.code === 'Enter') {
+    // Confirm popup
+    if (Popups.reactive.confirm?.ok) Popups.reactive.confirm.ok()
+  }
 }
 
 const onWheel = Mouse.getWheelDebouncer(WheelDirection.Horizontal, e => {


### PR DESCRIPTION
Currently popups can be closed by pressing the Esc Key. However, they cannot be confirmed by pressing the Enter Key. This PR adds this functionality.