### PR TITLE
Optimize moving tabs inside the same window

### DIFF
--- a/src/services/tabs.fg.move.ts
+++ b/src/services/tabs.fg.move.ts
@@ -160,6 +160,10 @@ export async function move(
     return
   }
 
+  // Info about the moved tabs previous state:
+  const oneAfterAnother = tabs.every((tab, ix) => ix === 0 || tab.index === tabs[ix - 1].index + 1)
+  const srcIndex = tabs[0].index
+
   const ids = []
   let dstIndexIncluded = -1
   let prevIndex = 0
@@ -286,13 +290,10 @@ export async function move(
   }
 
   // Move tabs
-  const nativeDstIndex = dst.index <= tabs[0].index ? dst.index : dst.index - 1
-  const canSkipMove =
-    tabs[0].index <= nativeDstIndex &&
-    nativeDstIndex <= tabs[tabs.length - 1].index &&
-    // all tabs go one after another:
-    tabs.every((tab, ix) => ix === 0 || tab.index === tabs[ix - 1].index + 1)
+  const samePosition = srcIndex === tabs[0].index
+  const canSkipMove = oneAfterAnother && samePosition
   if (!canSkipMove) {
+    const nativeDstIndex = dst.index <= tabs[0].index ? dst.index : dst.index - 1
     await browser.tabs.move(ids, { windowId: Windows.id, index: nativeDstIndex }).catch(err => {
       Logs.err('Tabs.move: Cannot move native tabs', err)
     })

--- a/src/services/tabs.fg.move.ts
+++ b/src/services/tabs.fg.move.ts
@@ -195,7 +195,7 @@ export async function move(
 
     // Update parent-child relation
     const oldParent = Tabs.byId[tab.parentId]
-    if (!oldParent || !tabs.includes(oldParent)) {
+    if (tab.parentId !== dst.parentId && (!oldParent || !tabs.includes(oldParent))) {
       tab.parentId = dst.parentId
 
       if (dstParent) browser.tabs.update(tab.id, { openerTabId: dst.parentId })
@@ -287,10 +287,16 @@ export async function move(
 
   // Move tabs
   const nativeDstIndex = dst.index <= tabs[0].index ? dst.index : dst.index - 1
-  // TODO: Do not call this fn if: all tabs go one after another and srcIndex === dstIndex
-  await browser.tabs.move(ids, { windowId: Windows.id, index: nativeDstIndex }).catch(err => {
-    Logs.err('Tabs.move: Cannot move native tabs', err)
-  })
+  const canSkipMove =
+    tabs[0].index <= nativeDstIndex &&
+    nativeDstIndex <= tabs[tabs.length - 1].index &&
+    // all tabs go one after another:
+    tabs.every((tab, ix) => ix === 0 || tab.index === tabs[ix - 1].index + 1)
+  if (!canSkipMove) {
+    await browser.tabs.move(ids, { windowId: Windows.id, index: nativeDstIndex }).catch(err => {
+      Logs.err('Tabs.move: Cannot move native tabs', err)
+    })
+  }
 
   // Reset moving tabs marks
   tabs.forEach(t => (t.moving = undefined))


### PR DESCRIPTION
I noticed that moving all tabs inside a window to a new panel could be quite slow so I took a look at the code in order to optimize it. I suspect that it was the left over `TODO: Do not call this fn if: all tabs go one after another and srcIndex === dstIndex` that was the cause of my issue so I implemented a check for that condition and when I ran the code in the debugger the `browser.tabs.move` function was indeed not called when moving all tabs to a new panel.