### PR TITLE
Don't count double-clicking the title editor as double-clicking the tab

### DIFF
--- a/src/sidebar/components/tab.vue
+++ b/src/sidebar/components/tab.vue
@@ -337,6 +337,8 @@ function onCtxMenu(e: MouseEvent): void {
 }
 
 function onDoubleClick(): void {
+  if (tab.reactive.customTitleEdit) return
+
   const dc = Settings.state.tabDoubleClick
   if (dc === 'reload') Tabs.reloadTabs([tab.id])
   if (dc === 'duplicate') Tabs.duplicateTabs([tab.id])


### PR DESCRIPTION
That is, if a tab action is set to run when double-clicking on a tab, and you double-click the text while editing a tab's title, don't run the tab action.

I noticed this because I have double-click set to edit title, and tried to double-click while editing to select a word, however this is what happens:

https://github.com/mbnuqw/sidebery/assets/9437625/1a1ff240-03fa-44d0-a64e-e0d139fd84ee

It re-runs the action, resetting the title value and the selection. Note that this change only affects double-clicks inside the text input field, because if you click a different part of the tab, the first click will blur the input.