### PR TITLE
Fix: Scroll thresholds not applying to mouse debouncer

### DIFF
--- a/src/_locales/dict.setup-page.ts
+++ b/src/_locales/dict.setup-page.ts
@@ -3055,9 +3055,6 @@ Beispiele: "*", "ctrl+$", "ctrl+alt+g"`,
     zh_CN: '每次滚动仅切换一个面板',
     zh_TW: '每次捲動僅切換一個面板',
   },
-  'settings.panel_switch_threshold': {
-    en: 'Horizontal scroll threshold for panel switch',
-  },
   'settings.scroll_through_tabs': {
     en: 'Switch tabs with scroll wheel',
     ru: 'Переключать вкладки с помощью колеса прокрутки',

--- a/src/_locales/dict.setup-page.ts
+++ b/src/_locales/dict.setup-page.ts
@@ -3055,6 +3055,9 @@ Beispiele: "*", "ctrl+$", "ctrl+alt+g"`,
     zh_CN: '每次滚动仅切换一个面板',
     zh_TW: '每次捲動僅切換一個面板',
   },
+  'settings.panel_switch_threshold': {
+    en: 'Horizontal scroll threshold for panel switch',
+  },
   'settings.scroll_through_tabs': {
     en: 'Switch tabs with scroll wheel',
     ru: 'Переключать вкладки с помощью колеса прокрутки',

--- a/src/_locales/dict.setup-page.ts
+++ b/src/_locales/dict.setup-page.ts
@@ -3055,6 +3055,9 @@ Beispiele: "*", "ctrl+$", "ctrl+alt+g"`,
     zh_CN: '每次滚动仅切换一个面板',
     zh_TW: '每次捲動僅切換一個面板',
   },
+  'settings.wheel_accumulation': {
+    en: 'Scroll wheel accumulation',
+  },
   'settings.scroll_through_tabs': {
     en: 'Switch tabs with scroll wheel',
     ru: 'Переключать вкладки с помощью колеса прокрутки',

--- a/src/_locales/dict.setup-page.ts
+++ b/src/_locales/dict.setup-page.ts
@@ -3055,8 +3055,11 @@ Beispiele: "*", "ctrl+$", "ctrl+alt+g"`,
     zh_CN: '每次滚动仅切换一个面板',
     zh_TW: '每次捲動僅切換一個面板',
   },
-  'settings.wheel_accumulation': {
-    en: 'Scroll wheel accumulation',
+  'settings.wheel_accumulation_x': {
+    en: 'Horizontal scroll wheel accumulation',
+  },
+  'settings.wheel_accumulation_y': {
+    en: 'Vertical scroll wheel accumulation',
   },
   'settings.scroll_through_tabs': {
     en: 'Switch tabs with scroll wheel',
@@ -3372,6 +3375,9 @@ Beispiele: "*", "ctrl+$", "ctrl+alt+g"`,
     zh_CN: '标签页面板操作',
     zh_TW: '分頁面板操作',
     de: 'Aktionen mit Tab-Panels',
+  },
+  'settings.accumulation_options_sub_title': {
+    en: 'Accumulation Options',
   },
   'settings.tabs_panel_left_click_action': {
     en: 'Left click on tabs panel',

--- a/src/defaults/settings.ts
+++ b/src/defaults/settings.ts
@@ -173,7 +173,8 @@ export const DEFAULT_SETTINGS: SettingsState = {
   // Mouse
   hScrollAction: 'none',
   onePanelSwitchPerScroll: false,
-  wheelAccumulation: true,
+  wheelAccumulationX: true,
+  wheelAccumulationY: true,
   navSwitchPanelsDelay: 128,
   scrollThroughTabs: 'none',
   scrollThroughVisibleTabs: true,

--- a/src/defaults/settings.ts
+++ b/src/defaults/settings.ts
@@ -173,6 +173,7 @@ export const DEFAULT_SETTINGS: SettingsState = {
   // Mouse
   hScrollAction: 'none',
   onePanelSwitchPerScroll: false,
+  wheelAccumulation: true,
   navSwitchPanelsDelay: 128,
   scrollThroughTabs: 'none',
   scrollThroughVisibleTabs: true,

--- a/src/defaults/settings.ts
+++ b/src/defaults/settings.ts
@@ -173,7 +173,6 @@ export const DEFAULT_SETTINGS: SettingsState = {
   // Mouse
   hScrollAction: 'none',
   onePanelSwitchPerScroll: false,
-  panelSwitchThreshold: 0,
   navSwitchPanelsDelay: 128,
   scrollThroughTabs: 'none',
   scrollThroughVisibleTabs: true,

--- a/src/defaults/settings.ts
+++ b/src/defaults/settings.ts
@@ -173,6 +173,7 @@ export const DEFAULT_SETTINGS: SettingsState = {
   // Mouse
   hScrollAction: 'none',
   onePanelSwitchPerScroll: false,
+  panelSwitchThreshold: 0,
   navSwitchPanelsDelay: 128,
   scrollThroughTabs: 'none',
   scrollThroughVisibleTabs: true,

--- a/src/page.setup/components/settings.mouse.vue
+++ b/src/page.setup/components/settings.mouse.vue
@@ -15,6 +15,13 @@ section(ref="el")
       v-model:value="Settings.state.onePanelSwitchPerScroll"
       :inactive="Settings.state.hScrollAction !== 'switch_panels'"
       @update:value="Settings.saveDebounced(150)")
+    NumField.-inline(
+      label="settings.panel_switch_threshold"
+      v-model:value="Settings.state.panelSwitchThreshold"
+      :inactive="Settings.state.hScrollAction !== 'switch_panels'"
+      :or="0"
+      :allowNegative="false"
+      @update:value="Settings.saveDebounced(500)")
   SelectField(
     label="settings.scroll_through_tabs"
     optLabel="settings.scroll_through_tabs_"

--- a/src/page.setup/components/settings.mouse.vue
+++ b/src/page.setup/components/settings.mouse.vue
@@ -15,13 +15,6 @@ section(ref="el")
       v-model:value="Settings.state.onePanelSwitchPerScroll"
       :inactive="Settings.state.hScrollAction !== 'switch_panels'"
       @update:value="Settings.saveDebounced(150)")
-    NumField.-inline(
-      label="settings.panel_switch_threshold"
-      v-model:value="Settings.state.panelSwitchThreshold"
-      :inactive="Settings.state.hScrollAction !== 'switch_panels'"
-      :or="0"
-      :allowNegative="false"
-      @update:value="Settings.saveDebounced(500)")
   SelectField(
     label="settings.scroll_through_tabs"
     optLabel="settings.scroll_through_tabs_"

--- a/src/page.setup/components/settings.mouse.vue
+++ b/src/page.setup/components/settings.mouse.vue
@@ -15,10 +15,6 @@ section(ref="el")
       v-model:value="Settings.state.onePanelSwitchPerScroll"
       :inactive="Settings.state.hScrollAction !== 'switch_panels'"
       @update:value="Settings.saveDebounced(150)")
-  ToggleField(
-    label="settings.wheel_accumulation"
-    v-model:value="Settings.state.wheelAccumulation"
-    @update:value="Settings.saveDebounced(150)")
   SelectField(
     label="settings.scroll_through_tabs"
     optLabel="settings.scroll_through_tabs_"
@@ -84,6 +80,17 @@ section(ref="el")
       :inactive="!Settings.state.wheelThreshold"
       :or="10"
       @update:value="Settings.saveDebounced(500)")
+
+  .wrapper
+    .sub-title: .text {{translate('settings.accumulation_options_sub_title')}}
+    ToggleField.-no-separator(
+      label="settings.wheel_accumulation_x"
+      v-model:value="Settings.state.wheelAccumulationX"
+      @update:value="Settings.saveDebounced(150)")
+    ToggleField(
+      label="settings.wheel_accumulation_y"
+      v-model:value="Settings.state.wheelAccumulationY"
+      @update:value="Settings.saveDebounced(150)")
 
   .wrapper
     .sub-title: .text {{translate('settings.nav_actions_sub_title')}}

--- a/src/page.setup/components/settings.mouse.vue
+++ b/src/page.setup/components/settings.mouse.vue
@@ -15,6 +15,10 @@ section(ref="el")
       v-model:value="Settings.state.onePanelSwitchPerScroll"
       :inactive="Settings.state.hScrollAction !== 'switch_panels'"
       @update:value="Settings.saveDebounced(150)")
+  ToggleField(
+    label="settings.wheel_accumulation"
+    v-model:value="Settings.state.wheelAccumulation"
+    @update:value="Settings.saveDebounced(150)")
   SelectField(
     label="settings.scroll_through_tabs"
     optLabel="settings.scroll_through_tabs_"

--- a/src/services/mouse.actions.ts
+++ b/src/services/mouse.actions.ts
@@ -263,15 +263,12 @@ export function getWheelDebouncer(
   else threshold = Settings.state.wheelThresholdX
 
   let stopTimeout: number | undefined
-  let first = true
   let delta = 0
-  let deltaBuf = 0
 
   return (e: WheelEvent) => {
     clearTimeout(stopTimeout)
     stopTimeout = setTimeout(() => {
-      deltaBuf = 0
-      first = true
+      delta = 0
       stopTimeout = undefined
     }, 500)
 
@@ -281,11 +278,9 @@ export function getWheelDebouncer(
     if (e.deltaMode !== 0) return cb(e)
 
     delta = direction === WheelDirection.Vertical ? e.deltaY : e.deltaX
-    if (!first && delta) deltaBuf += delta
-    else first = false
 
-    if (deltaBuf > threshold || deltaBuf < -threshold) {
-      deltaBuf = 0
+    if (delta > threshold || delta < -threshold) {
+      delta = 0
       cb(e)
     }
   }

--- a/src/services/mouse.actions.ts
+++ b/src/services/mouse.actions.ts
@@ -258,19 +258,26 @@ export function getWheelDebouncer(
 ): (e: WheelEvent) => void {
   if (!Settings.state.wheelThreshold) return cb
 
-  let threshold = 0
-  if (direction === WheelDirection.Vertical) threshold = Settings.state.wheelThresholdY
-  else threshold = Settings.state.wheelThresholdX
-
   let stopTimeout: number | undefined
   let first = true
   let delta = 0
   let deltaBuf = 0
 
   return (e: WheelEvent) => {
+    // Keep values in the callback so they can update with settings on the fly
+    let threshold = 0
+    let accumulation = true
+    if (direction === WheelDirection.Vertical) {
+      threshold = Settings.state.wheelThresholdY
+      accumulation = Settings.state.wheelAccumulationY
+    } else {
+      threshold = Settings.state.wheelThresholdX
+      accumulation = Settings.state.wheelAccumulationX
+    }
+
     clearTimeout(stopTimeout)
     stopTimeout = setTimeout(() => {
-      if (Settings.state.wheelAccumulation) {
+      if (accumulation) {
         deltaBuf = 0
         first = true
       } else {
@@ -285,7 +292,7 @@ export function getWheelDebouncer(
     if (e.deltaMode !== 0) return cb(e)
 
     delta = direction === WheelDirection.Vertical ? e.deltaY : e.deltaX
-    if (Settings.state.wheelAccumulation) {
+    if (accumulation) {
       if (!first && delta) deltaBuf += delta
       else first = false
     } else {
@@ -293,7 +300,7 @@ export function getWheelDebouncer(
     }
 
     if (deltaBuf > threshold || deltaBuf < -threshold) {
-      if (Settings.state.wheelAccumulation) {
+      if (accumulation) {
         deltaBuf = 0
       } else {
         delta = 0

--- a/src/services/mouse.actions.ts
+++ b/src/services/mouse.actions.ts
@@ -263,12 +263,19 @@ export function getWheelDebouncer(
   else threshold = Settings.state.wheelThresholdX
 
   let stopTimeout: number | undefined
+  let first = true
   let delta = 0
+  let deltaBuf = 0
 
   return (e: WheelEvent) => {
     clearTimeout(stopTimeout)
     stopTimeout = setTimeout(() => {
-      delta = 0
+      if (Settings.state.wheelAccumulation) {
+        deltaBuf = 0
+        first = true
+      } else {
+        delta = 0
+      }
       stopTimeout = undefined
     }, 500)
 
@@ -278,9 +285,19 @@ export function getWheelDebouncer(
     if (e.deltaMode !== 0) return cb(e)
 
     delta = direction === WheelDirection.Vertical ? e.deltaY : e.deltaX
+    if (Settings.state.wheelAccumulation) {
+      if (!first && delta) deltaBuf += delta
+      else first = false
+    } else {
+      deltaBuf = delta
+    }
 
-    if (delta > threshold || delta < -threshold) {
-      delta = 0
+    if (deltaBuf > threshold || deltaBuf < -threshold) {
+      if (Settings.state.wheelAccumulation) {
+        deltaBuf = 0
+      } else {
+        delta = 0
+      }
       cb(e)
     }
   }

--- a/src/sidebar/sidebar.vue
+++ b/src/sidebar/sidebar.vue
@@ -294,8 +294,10 @@ let lastDir: number | undefined
 const onWheel = Mouse.getWheelDebouncer(WheelDirection.Horizontal, e => {
   if (Menu.isOpen) Menu.close()
 
-  if (e.deltaX !== 0) Mouse.blockWheel(WheelDirection.Vertical)
-  if (e.deltaX === 0) return
+  if (Math.abs(e.deltaX) > Settings.state.panelSwitchThreshold)
+    Mouse.blockWheel(WheelDirection.Vertical)
+  else
+    return
 
   if (Settings.state.hScrollAction === 'switch_panels') {
     const dir = e.deltaX > 0 ? 1 : -1

--- a/src/sidebar/sidebar.vue
+++ b/src/sidebar/sidebar.vue
@@ -294,7 +294,7 @@ let lastDir: number | undefined
 const onWheel = Mouse.getWheelDebouncer(WheelDirection.Horizontal, e => {
   if (Menu.isOpen) Menu.close()
 
-  if (Math.abs(e.deltaX) > Settings.state.panelSwitchThreshold)
+  if (e.deltaX !== 0)
     Mouse.blockWheel(WheelDirection.Vertical)
   else
     return

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -177,7 +177,6 @@ export interface SettingsState {
   hScrollThroughPanels?: boolean // DEPR
   hScrollAction: (typeof SETTINGS_OPTIONS.hScrollAction)[number]
   onePanelSwitchPerScroll: boolean
-  panelSwitchThreshold: number
   scrollThroughTabs: (typeof SETTINGS_OPTIONS.scrollThroughTabs)[number]
   scrollThroughVisibleTabs: boolean
   scrollThroughTabsSkipDiscarded: boolean

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -176,7 +176,8 @@ export interface SettingsState {
   // Mouse
   hScrollThroughPanels?: boolean // DEPR
   hScrollAction: (typeof SETTINGS_OPTIONS.hScrollAction)[number]
-  onePanelSwitchPerScroll: boolean
+  onePanelSwitchPerScroll: boolean,
+  panelSwitchThreshold: number,
   scrollThroughTabs: (typeof SETTINGS_OPTIONS.scrollThroughTabs)[number]
   scrollThroughVisibleTabs: boolean
   scrollThroughTabsSkipDiscarded: boolean

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -176,7 +176,8 @@ export interface SettingsState {
   // Mouse
   hScrollThroughPanels?: boolean // DEPR
   hScrollAction: (typeof SETTINGS_OPTIONS.hScrollAction)[number]
-  onePanelSwitchPerScroll: boolean
+  onePanelSwitchPerScroll: boolean,
+  wheelAccumulation: boolean,
   scrollThroughTabs: (typeof SETTINGS_OPTIONS.scrollThroughTabs)[number]
   scrollThroughVisibleTabs: boolean
   scrollThroughTabsSkipDiscarded: boolean

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -176,8 +176,8 @@ export interface SettingsState {
   // Mouse
   hScrollThroughPanels?: boolean // DEPR
   hScrollAction: (typeof SETTINGS_OPTIONS.hScrollAction)[number]
-  onePanelSwitchPerScroll: boolean,
-  panelSwitchThreshold: number,
+  onePanelSwitchPerScroll: boolean
+  panelSwitchThreshold: number
   scrollThroughTabs: (typeof SETTINGS_OPTIONS.scrollThroughTabs)[number]
   scrollThroughVisibleTabs: boolean
   scrollThroughTabsSkipDiscarded: boolean

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -177,7 +177,8 @@ export interface SettingsState {
   hScrollThroughPanels?: boolean // DEPR
   hScrollAction: (typeof SETTINGS_OPTIONS.hScrollAction)[number]
   onePanelSwitchPerScroll: boolean,
-  wheelAccumulation: boolean,
+  wheelAccumulationX: boolean,
+  wheelAccumulationY: boolean,
   scrollThroughTabs: (typeof SETTINGS_OPTIONS.scrollThroughTabs)[number]
   scrollThroughVisibleTabs: boolean
   scrollThroughTabsSkipDiscarded: boolean


### PR DESCRIPTION
I have problems on my laptop where I switch panels when I meant to scroll through the tabs in a panel, so I added a threshold value that should take care of it. It defaults to 0 which is the original behavior.