### PR TITLE
chore: manifest v3 (#916)

### DIFF
--- a/src/bg/background.ts
+++ b/src/bg/background.ts
@@ -129,7 +129,7 @@ void (async function main() {
 function initToolbarButton(): void {
   Menu.createSettingsMenu()
 
-  browser.browserAction.onClicked.addListener((_, info): void => {
+  browser.action.onClicked.addListener((_, info): void => {
     if (info && info.button === 1) browser.runtime.openOptionsPage()
     else browser.sidebarAction.toggle()
   })

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -28,6 +28,7 @@
     "storage",
     "unlimitedStorage",
     "sessions",
+    "scripting",
     "menus",
     "menus.overrideContext",
     "search",

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,5 +1,5 @@
 {
-  "manifest_version": 2,
+  "manifest_version": 3,
   "browser_specific_settings": {
     "gecko": {
       "id": "{3c078156-979c-498b-8990-85f7987dd929}",
@@ -34,7 +34,6 @@
     "theme"
   ],
   "optional_permissions": [
-    "<all_urls>",
     "proxy",
     "webRequest",
     "webRequestBlocking",
@@ -43,6 +42,9 @@
     "clipboardWrite",
     "history",
     "downloads"
+  ],
+  "host_permissions": [
+    "<all_urls>"
   ],
   "sidebar_action": {
     "default_icon": "./assets/logo-native.svg",
@@ -424,7 +426,7 @@
       "description": "__MSG_KbSortPanelTabsByTimeDes__"
     }
   },
-  "browser_action": {
+  "action": {
     "default_icon": "./assets/logo-native.svg",
     "default_title": "__MSG_ActionTitle__",
     "default_area": "navbar",

--- a/src/services/menu.actions.ts
+++ b/src/services/menu.actions.ts
@@ -107,15 +107,23 @@ export function createSettingsMenu(): void {
     id: 'open_settings',
     title: translate('menu.browserAction.open_settings'),
     icons: { '16': 'assets/logo-native.svg' },
-    onclick: () => browser.runtime.openOptionsPage(),
-    contexts: ['browser_action'],
+    contexts: ['action'],
   })
   browser.menus.create({
     id: 'create_snapshot',
     title: translate('menu.browserAction.create_snapshot'),
     icons: { '16': 'assets/snapshot-native.svg' },
-    onclick: () => Snapshots.createSnapshot(),
-    contexts: ['browser_action'],
+    contexts: ['action'],
+  })
+  browser.menus.onClicked.addListener((info, tab) => {
+    switch (info.menuItemId) {
+      case 'open_settings':
+        browser.runtime.openOptionsPage()
+        break
+      case 'create_snapshot':
+        Snapshots.createSnapshot()
+        break
+    }
   })
 }
 

--- a/src/services/search.actions.ts
+++ b/src/services/search.actions.ts
@@ -429,12 +429,12 @@ export function start(): void {
 
   const hasFocus = document.hasFocus()
   if (!hasFocus) {
-    browser.browserAction.setPopup({ popup: SEARCH_URL })
-    browser.browserAction.openPopup()
+    browser.action.setPopup({ popup: SEARCH_URL })
+    browser.action.openPopup()
     Search.reactive.barIsActive = true
 
     // Reset browser action
-    setTimeout(() => browser.browserAction.setPopup({ popup: null }), 500)
+    setTimeout(() => browser.action.setPopup({ popup: null }), 500)
   }
 
   showBar()

--- a/src/services/tabs.bg.actions.ts
+++ b/src/services/tabs.bg.actions.ts
@@ -514,22 +514,26 @@ export async function initInternalPageScripts(tabs: Tab[]) {
 
 export function injectUrlPageScript(winId: ID, tabId: ID) {
   try {
-    browser.tabs
-      .executeScript(tabId, {
-        file: '/injections/url.js',
-        runAt: 'document_start',
-        matchAboutBlank: true,
+    browser.scripting
+      .executeScript({
+        files: ['/injections/url.js'],
+        target: { tabId },
+        injectImmediately: true,
       })
       .catch(err => {
         Logs.warn('Tabs.injectUrlPageScript: Cannot inject script, tabId:', tabId, err)
       })
     const initData = getUrlPageInitData(winId, tabId)
     const initDataJson = JSON.stringify(initData)
-    browser.tabs
-      .executeScript(tabId, {
-        code: `window.sideberyInitData=${initDataJson};window.onSideberyInitDataReady?.()`,
-        runAt: 'document_start',
-        matchAboutBlank: true,
+    browser.scripting
+      .executeScript<[string], void>({
+        args: [initDataJson],
+        func: (initDataJson: string) => {
+          window.sideberyInitData = JSON.parse(initDataJson);
+          window.onSideberyInitDataReady?.()
+        },
+        target: { tabId },
+        injectImmediately: true,
       })
       .catch(() => {
         Logs.warn('Tabs.injectUrlPageScript: Cannot inject init data, reloading tab (if active)...')
@@ -576,22 +580,26 @@ export async function injectGroupPageScript(winId: ID, tabId: ID): Promise<void>
   injectingGroup.add(tabId)
 
   try {
-    browser.tabs
-      .executeScript(tabId, {
-        file: '/injections/group.js',
-        runAt: 'document_start',
-        matchAboutBlank: true,
+    browser.scripting
+      .executeScript({
+        files: ['/injections/group.js'],
+        target: { tabId },
+        injectImmediately: true,
       })
       .catch(err => {
         Logs.warn('Tabs.injectGroupPageScript: Cannot inject script, tabId:', tabId, err)
       })
     const initData = await getGroupPageInitData(winId, tabId)
     const initDataJson = JSON.stringify(initData)
-    browser.tabs
-      .executeScript(tabId, {
-        code: `window.sideberyInitData=${initDataJson};window.onSideberyInitDataReady?.()`,
-        runAt: 'document_start',
-        matchAboutBlank: true,
+    browser.scripting
+      .executeScript<[string], void>({
+        args: [initDataJson],
+        func: (initDataJson: string) => {
+          window.sideberyInitData = JSON.parse(initDataJson);
+          window.onSideberyInitDataReady?.()
+        },
+        target: { tabId },
+        injectImmediately: true,
       })
       .catch(() => {
         Logs.warn('Tabs.injectGroupPageScript: Cannot inject init data, reloading tab')

--- a/src/styles/themes/proton/sidebar/sidebar.styl
+++ b/src/styles/themes/proton/sidebar/sidebar.styl
@@ -48,6 +48,7 @@ body
   height: 100%
   -webkit-font-smoothing: antialiased
   -moz-osx-font-smoothing: grayscale
+  font-family: sans-serif
   padding: 0
   margin: 0
 

--- a/src/styles/themes/proton/sidebar/sidebar.styl
+++ b/src/styles/themes/proton/sidebar/sidebar.styl
@@ -42,6 +42,9 @@ html
   position: relative
   height: 100%
 
+*
+  box-sizing: border-box
+
 body
   position: relative
   width: 100%
@@ -51,6 +54,7 @@ body
   font-family: sans-serif
   padding: 0
   margin: 0
+  cursor: default
 
   a
     text-decoration: none

--- a/src/types/web-ext.d.ts
+++ b/src/types/web-ext.d.ts
@@ -312,15 +312,6 @@ declare namespace browser {
       active?: boolean
     }
 
-    interface ExecuteOpts {
-      allFrames?: boolean
-      code?: string
-      file?: string
-      frameId?: number
-      matchAboutBlank?: boolean
-      runAt?: 'document_start' | 'document_end' | 'document_idle'
-    }
-
     function create(createProperties: CreateProperties): Promise<Tab>
     function query(options: TabsQueryOptions): Promise<Tab[]>
     function remove(tabIds: ID | ID[]): Promise<void>
@@ -340,7 +331,6 @@ declare namespace browser {
     function getCurrent(): Promise<Tab>
     function saveAsPDF(pageSettings: PageSettings): Promise<SavePDFResult>
     function duplicate(tabId: ID, opts?: DuplOpts): Promise<Tab>
-    function executeScript(tabId: ID, opts: ExecuteOpts): Promise<any[]>
     function warmup(tabId: ID): Promise<void>
 
     interface RemoveInfo {
@@ -1413,5 +1403,32 @@ declare namespace browser {
     type ThemeUpdatedListener = (upd: Update) => void
 
     const onUpdated: EventTarget<ThemeUpdatedListener>
+  }
+
+  namespace scripting {
+    interface InjectionTarget {
+      allFrames?: boolean
+      frameIds?: number[]
+      tabId: ID
+    }
+
+    type ExecutionWorld = 'ISOLATED' | 'MAIN'
+
+    interface InjectDetails<Args extends unknown[] = unknown[], Result = unknown> {
+      args?: Args
+      files?: string[]
+      func?: (...args: Args) => Result
+      injectImmediately?: boolean
+      target: InjectionTarget
+      world?: ExecutionWorld
+    }
+
+    interface InjectionResult<T> {
+      frameId: number
+      result?: T
+      error?: unknown // unsupported by chrome
+    }
+
+    function executeScript<Args extends unknown[], Result>(details: InjectDetails<Args, Result>): Promise<InjectionResult<Result>[]>
   }
 }

--- a/src/types/web-ext.d.ts
+++ b/src/types/web-ext.d.ts
@@ -497,7 +497,7 @@ declare namespace browser {
   /**
    * Browser action button
    */
-  namespace browserAction {
+  namespace action {
     type BrowserActionButton = 0 | 1
 
     interface PopupDetails {
@@ -562,7 +562,7 @@ declare namespace browser {
    */
   namespace menus {
     // prettier-ignore
-    type ContextType = 'all' | 'audio' | 'bookmark' | 'browser_action'
+    type ContextType = 'all' | 'audio' | 'bookmark' | 'action'
     | 'editable' | 'frame' | 'image' | 'link' | 'page' | 'page_action'
     | 'password' | 'selection' | 'tab' | 'tools_menu' | 'video'
 
@@ -606,6 +606,14 @@ declare namespace browser {
     function overrideContext(contextOptions: ContextOptions): void
 
     const onHidden: EventTarget<HiddenListener>
+
+    interface OnClickData {
+      button?: number
+      menuItemId: string
+    }
+    type ClickListener = (info: OnClickData, tab: tabs.Tab) => void
+
+    const onClicked: EventTarget<ClickListener>
   }
 
   /**


### PR DESCRIPTION
i'm not entirely sure i did everything, this seems like too few changes for a v3 migration. sorry for being dumb in advance. 

one thing im most unsure about is this part:
> The [Scripting API](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/scripting) takes over the features of tabs.insertCSS(), tabs.removeCSS(), and tabs.executeScript() and adds capabilities to register, update, and unregister content scripts at runtime.

i've seen quite a few usages of executeScript, but the extension seems to be working fine despite using them? 
and i also didn't really understand what those calls are used for in the first place

also im not sure how do i do a regression test, there don't seem to be any kind of tests in the repo

closes #916