### PR TITLE
feat: open window (from drag) under mouse

### DIFF
--- a/src/services/drag-and-drop.actions.ts
+++ b/src/services/drag-and-drop.actions.ts
@@ -1191,6 +1191,13 @@ export function resetOther(): void {
 
 let dragEndedRecentlyTimeout: number | undefined
 
+let relativeMouseX = 0
+let relativeMouseY = 0
+export function onDragStart(e: DragEvent): void {
+  relativeMouseX = e.clientX
+  relativeMouseY = e.clientY + (window.outerHeight - window.innerHeight) //account for window height
+}
+
 export async function onDragEnd(e: DragEvent): Promise<void> {
   resetDragPointer()
   DnD.resetOther()
@@ -1237,13 +1244,22 @@ export async function onDragEnd(e: DragEvent): Promise<void> {
       return
     }
 
+    const mouseX = e.screenX
+    const mouseY = e.screenY
+
     const fromTabs = info.type === DragType.Tabs
     const fromTabsPanel = info.type === DragType.TabsPanel
     const fromBookmarks = info.type === DragType.Bookmarks
     const fromBookmarksPanel = info.type === DragType.BookmarksPanel
 
     if (fromTabs && info.items?.length) {
-      const dst = { windowId: NEWID, incognito: Windows.incognito, panelId: info.panelId }
+      const dst = {
+        windowId: NEWID,
+        incognito: Windows.incognito,
+        panelId: info.panelId,
+        top: mouseY - relativeMouseY,
+        left: mouseX - relativeMouseX,
+      }
       if (mode === 'copy') Tabs.open(info.items, dst)
       else Tabs.move(info.items, {}, dst)
     }

--- a/src/services/drag-and-drop.actions.ts
+++ b/src/services/drag-and-drop.actions.ts
@@ -1246,7 +1246,12 @@ export async function onDragEnd(e: DragEvent): Promise<void> {
 
     const mouseX = e.screenX
     const mouseY = e.screenY
-
+    let maximized = false
+    await browser.windows.getCurrent().then(function (window) {
+      if (window.state === 'maximized') {
+        maximized = true
+      }
+    })
     const fromTabs = info.type === DragType.Tabs
     const fromTabsPanel = info.type === DragType.TabsPanel
     const fromBookmarks = info.type === DragType.Bookmarks
@@ -1259,6 +1264,7 @@ export async function onDragEnd(e: DragEvent): Promise<void> {
         panelId: info.panelId,
         top: mouseY - relativeMouseY,
         left: mouseX - relativeMouseX,
+        maximized: maximized,
       }
       if (mode === 'copy') Tabs.open(info.items, dst)
       else Tabs.move(info.items, {}, dst)

--- a/src/services/tabs.fg.move.ts
+++ b/src/services/tabs.fg.move.ts
@@ -57,7 +57,7 @@ export async function move(
   if (dst.windowId === NEWID) {
     Tabs.detachTabs(tabsInfo.map(t => t.id))
     const info = Utils.cloneArray<ItemInfo>(tabsInfo)
-    const conf = { incognito: dst.incognito, tabId: MOVEID }
+    const conf = { incognito: dst.incognito, tabId: MOVEID, top: dst.top, left: dst.left }
     info.forEach(t => (t.panelId = dst.panelId))
     IPC.bg('createWindowWithTabs', info, conf).finally(() => Tabs.detachingTabIds.clear())
     return

--- a/src/services/tabs.fg.move.ts
+++ b/src/services/tabs.fg.move.ts
@@ -12,6 +12,7 @@ import * as IPC from 'src/services/ipc'
 import * as Popups from 'src/services/popups'
 import * as Logs from 'src/services/logs'
 import * as Utils from 'src/utils'
+import WindowState = browser.windows.WindowState
 
 export async function move(
   tabsInfo: DeepReadonly<ItemInfo[]>,
@@ -57,7 +58,14 @@ export async function move(
   if (dst.windowId === NEWID) {
     Tabs.detachTabs(tabsInfo.map(t => t.id))
     const info = Utils.cloneArray<ItemInfo>(tabsInfo)
-    const conf = { incognito: dst.incognito, tabId: MOVEID, top: dst.top, left: dst.left }
+    const windowState = (dst.maximized === true ? 'maximized' : 'normal') as WindowState
+    const conf = {
+      incognito: dst.incognito,
+      tabId: MOVEID,
+      top: dst.top,
+      left: dst.left,
+      state: windowState,
+    }
     info.forEach(t => (t.panelId = dst.panelId))
     IPC.bg('createWindowWithTabs', info, conf).finally(() => Tabs.detachingTabIds.clear())
     return

--- a/src/sidebar/sidebar.vue
+++ b/src/sidebar/sidebar.vue
@@ -22,6 +22,7 @@
   :data-search="!!Search.reactive.value"
   :data-sticky-bookmarks="Settings.state.pinOpenedBookmarksFolder"
   :data-colorized-branches="Settings.state.colorizeTabsBranches"
+  @dragstart="DnD.onDragStart"
   @dragend="DnD.onDragEnd"
   @dragenter="DnD.onDragEnter"
   @dragleave="DnD.onDragLeave"

--- a/src/types.ts
+++ b/src/types.ts
@@ -214,6 +214,8 @@ export interface DstPlaceInfo {
   containerId?: string
   windowId?: ID
   incognito?: boolean
+  left?: number
+  top?: number
   windowChooseConf?: WindowChoosingDetails
   discarded?: boolean
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -216,6 +216,7 @@ export interface DstPlaceInfo {
   incognito?: boolean
   left?: number
   top?: number
+  maximized?: boolean
   windowChooseConf?: WindowChoosingDetails
   discarded?: boolean
 }


### PR DESCRIPTION
This PR makes new windows opened by dragging a tab from sidebery to outside the container open directly under the mouse.

The new window will open with an offset relative to where the user's mouse was inside the original window, mimicking Firefox's default tab behavior.

Tested on 1080p, 1440p, and multi-window.

<details>
  <summary>Before</summary>

  [![Before](https://github.com/mbnuqw/sidebery/assets/87634197/94351ac8-da82-48c7-9120-d874b7ba7dcb)](https://github.com/mbnuqw/sidebery/assets/87634197/94351ac8-da82-48c7-9120-d874b7ba7dcb)

</details>

<details>
  <summary>After</summary>

  [![After](https://github.com/mbnuqw/sidebery/assets/87634197/ce5b19e0-6bed-41a2-a5cb-975c3630fad2)](https://github.com/mbnuqw/sidebery/assets/87634197/ce5b19e0-6bed-41a2-a5cb-975c3630fad2)

</details>



