### PR TITLE
fix: setup-page: keybindings: button alignment

### DIFF
--- a/src/styles/themes/proton/page.setup/settings.keybindings.styl
+++ b/src/styles/themes/proton/page.setup/settings.keybindings.styl
@@ -64,6 +64,7 @@
 .keybinding > .value
   position: relative
   font-size: rem(13)
+  flex-shrink: 0
   padding: 2px 6px
   margin: auto 0 auto auto
   color: var(--toolbar-fg)
@@ -100,6 +101,7 @@
 
 .keybinding .icon-btn
   position: relative
+  flex-shrink: 0
   width: 28px
   height: 28px
   margin: auto -12px auto 4px


### PR DESCRIPTION
Prevent misalignment of buttons on the keybindings setup page when labels extend over multiple lines