### PR TITLE
Feat: Go to a Random Tab from Panel and selected Tabs

### DIFF
--- a/src/_locales/dict.common.ts
+++ b/src/_locales/dict.common.ts
@@ -1682,6 +1682,16 @@ export const commonTranslations: Translations = {
     zh_TW: '關閉其他分頁',
     ja: '他のタブを閉じる',
   },
+  'menu.tab.random_tab': {
+    en: 'Go to Random Tab',
+    de: 'Go to Random Tab',
+    hu: 'Go to Random Tab',
+    pl: 'Go to Random Tab',
+    ru: 'Go to Random Tab',
+    zh_CN: 'Go to Random Tab',
+    zh_TW: 'Go to Random Tab',
+    ja: 'Go to Random Tab',
+  },
   // - Tabs panel
   'menu.tabs_panel.mute_all_audible': {
     en: 'Mute all audible tabs',
@@ -1861,6 +1871,15 @@ export const commonTranslations: Translations = {
     ru: 'Удалить панель',
     zh: '移除面板',
     ja: 'パネルを削除',
+  },
+  'menu.tabs_panel.random_tab': {
+    en: 'Go to Random Tab',
+    de: 'Go to Random Tab',
+    hu: 'Go to Random Tab',
+    pl: 'Go to Random Tab',
+    ru: 'Go to Random Tab',
+    zh: 'Go to Random Tab',
+    ja: 'Go to Random Tab',
   },
   // - History
   'menu.history.open': {

--- a/src/page.setup/components/menu-editor.vue
+++ b/src/page.setup/components/menu-editor.vue
@@ -101,7 +101,7 @@
     .ctrls
       .btn(@click="resetBookmarksMenu") {{translate('menu.editor.reset')}}
       .btn(@click="createSeparator('bookmarks')") {{translate('menu.editor.create_separator')}}
-  
+
   section(ref="menuEditorBookmarksPanelEl" @click.stop @wheel="moveSelected($event, 'bookmarksPanel')")
     h2 {{translate('menu.editor.bookmarks_panel_title')}}
 
@@ -201,6 +201,7 @@ const TABS_MENU_OPTS: Record<string, string> = {
   closeTabsAbove: 'menu.tab.close_above',
   closeTabsBelow: 'menu.tab.close_below',
   closeOtherTabs: 'menu.tab.close_other',
+  goToRandomTabFromGroup: 'menu.tab.random_tab',
 }
 
 const TABS_PANEL_MENU_OPTS: Record<string, string> = {
@@ -225,6 +226,7 @@ const TABS_PANEL_MENU_OPTS: Record<string, string> = {
   sortAllTabsByUrlDescending: 'menu.tabs_panel.sort_all_by_url_des',
   sortAllTabsByAccessTimeAscending: 'menu.tabs_panel.sort_all_by_time_asc',
   sortAllTabsByAccessTimeDescending: 'menu.tabs_panel.sort_all_by_time_des',
+  goToRandomTabFromPanel: 'menu.tabs_panel.random_tab',
 }
 
 const BOOKMARKS_MENU_OPTS: Record<string, string> = {

--- a/src/services/menu.options.tabs.ts
+++ b/src/services/menu.options.tabs.ts
@@ -642,6 +642,24 @@ export const tabsMenuOptions: Record<string, () => MenuOption | MenuOption[] | u
     return option
   },
 
+  goToRandomTabFromGroup: () => {
+    const tabIds = Selection.get()
+
+    const option: MenuOption = {
+      label: 'Go to Random Tab',
+      icon: 'icon_reload',
+      onClick: () => {
+        const pick = tabIds[Math.floor(Math.random() * tabIds.length)];
+	      browser.tabs.update(pick, { active: true });
+      }
+    }
+
+    const firstTab = Tabs.byId[Selection.getFirst()]
+    if (!firstTab || tabIds.length <= 1) return
+
+    return option
+  },
+
   // ---
   // -- Panel options
   // -
@@ -907,6 +925,25 @@ export const tabsMenuOptions: Record<string, () => MenuOption | MenuOption[] | u
       onClick: () => TabsSorting.sort(TabsSorting.By.ATime, ids, -1, true),
     }
     if (!Settings.state.ctxMenuRenderInact && option.inactive) return
+    return option
+  },
+
+  goToRandomTabFromPanel: () => {
+    const panel = Sidebar.panelsById[Selection.getFirst()]
+
+    if (!Utils.isTabsPanel(panel)) return
+
+    const tabIds = panel.tabs.map(t => t.id) ?? []
+
+    const option: MenuOption = {
+      label: translate('menu.tabs_panel.random_tab'),
+      icon: 'icon_reload',
+      onClick: () => {
+        const pick = tabIds[Math.floor(Math.random() * tabIds.length)];
+	      browser.tabs.update(pick, { active: true });
+      }
+    }
+
     return option
   },
 }


### PR DESCRIPTION
## Description
Two different actions with similar names and translation. I didn't add the actions to the default menus.

Note: The translations for languages other than English are currently missing.

Closes #1605

## Known Issues
* I couldn't get it to behave as expected for trees and groups. You must right-click the "caret" so it opens the menu while selecting all child tabs for it to work.
* It's missing a unique icon. I'm currently using the "reload" icon.

## How to Test
1. Open the Menu Editor for Tabs and Tabs Panel and add the new "Go to Random Tab" action.
2. Right-click a panel to open the menu and test the new action.
3. Right-click a tab group or parent on their caret and test the new action.