### PR TITLE
Fix webext.run for zen-browser

### DIFF
--- a/build/webext.run.mjs
+++ b/build/webext.run.mjs
@@ -1,11 +1,12 @@
 import webExt from 'web-ext'
 import fs from 'node:fs'
+import path from 'node:path'
 import { ADDON_PATH } from './utils.js'
 
 let lastArg = process.argv[process.argv.length - 1]
 if (!lastArg || lastArg.startsWith('-')) lastArg = 'firefox'
 
-const IS_FF = lastArg.includes('irefox') || lastArg.includes('loorp')
+const IS_FF = lastArg.includes('irefox') || lastArg.includes('loorp') || lastArg.includes('zen')
 const cliOpts = {
   target: IS_FF ? 'firefox-desktop' : 'chromium',
   sourceDir: ADDON_PATH,
@@ -15,11 +16,11 @@ const cliOpts = {
 async function main() {
   if (IS_FF) {
     cliOpts.firefox = lastArg
-    cliOpts.firefoxProfile = './build/profile-' + lastArg
+    cliOpts.firefoxProfile = './build/profile-' + path.basename(lastArg).split(".")[0]
     await fs.promises.mkdir(cliOpts.firefoxProfile, { recursive: true })
   } else {
     cliOpts.chromiumBinary = lastArg
-    cliOpts.chromiumProfile = './build/profile-' + lastArg
+    cliOpts.chromiumProfile = './build/profile-' + path.basename(lastArg).split(".")[0]
     await fs.promises.mkdir(cliOpts.chromiumProfile, { recursive: true })
   }
 


### PR DESCRIPTION
This build script fails to create the profile directory when full path to browser is provided as the last argument. Fixes in this commit solves that, and also adds support for zen browser.