### PR TITLE
Allow reading variable tab height for tab bounds

### DIFF
--- a/src/services/sidebar.actions.ts
+++ b/src/services/sidebar.actions.ts
@@ -602,14 +602,9 @@ export function updateBounds(): void {
 function calcTabsBounds(panel: TabsPanel): ItemBounds[] {
   // Logs.info('Sidebar.calcTabsBounds', panel.id)
   const result: ItemBounds[] = []
-  const th = Sidebar.tabHeight
   const tm = Sidebar.tabMargin
-  if (th === 0) return result
-  const half = th >> 1
   const marginA = Math.floor(tm / 2)
   const marginB = Math.ceil(tm / 2)
-  const insideA = (half >> 1) + marginB + 2
-  const insideB = (half >> 1) + marginB - 2
 
   let overallHeight = -marginA
   let tabs = Tabs.list
@@ -623,6 +618,14 @@ function calcTabsBounds(panel: TabsPanel): ItemBounds[] {
   for (const tab of tabs) {
     if (tab.invisible || tab.pinned) continue
     if (tab.panelId !== panel.id) continue
+
+    // This method to get tab element taken from: https://github.com/mbnuqw/sidebery/blob/d74c2f70bcd9a980dcec02738a5260b171f5ecc1/src/services/tabs.fg.scroll.ts#L25
+    const elId = 'tab' + tab.id.toString()
+    const el = document.getElementById(elId)
+    const th = el.offsetHeight - tm
+    const half = th >> 1
+    const insideA = (half >> 1) + marginB + 2
+    const insideB = (half >> 1) + marginB - 2
 
     result.push({
       type: ItemBoundsType.Tab,


### PR DESCRIPTION
This branch allows for dragging tabs when using a non-uniform tab height, as mentioned in https://github.com/mbnuqw/sidebery/issues/1471

eg: If I want to apply this custom style, to let me read the full title of every tab,  I currently can't properly click and drag tabs.  As near as I can tell, this is due to tabs being assumed to be uniform height, and not reading from their dom elements.  This branch fixes that.

Next step after this would probably be adding a display option rather than requiring custom css.

The custom style I'm applying:

| Before |After |
|--------|--------|
|![image](https://github.com/user-attachments/assets/4b3d0890-2511-4fde-8c0b-e8032673a518) | ![image](https://github.com/user-attachments/assets/b595bd2a-8b46-451e-ac3f-1bd1184ebdb8) |


```
.Tab .body {
	border: 1px solid #c7c7c780;
}


#root {--tabs-height: auto !important;}
#root {--tabs-font-size: .8rem;}

.Tab .t-box {
  align-items: center;
  max-height: calc(var(--tabs-height) - var(--tabs-title-padding));
  overflow: hidden;
}


.Tab .title {
  font-size: var(--tabs-font-size);
	white-space: pre-wrap;
}


.Tab .close {
	width: 50px !important;
}
```