### PR TITLE
Stop changing window title on sidebar disconnect if markWindow setting is off

### DIFF
--- a/src/bg/background.ts
+++ b/src/bg/background.ts
@@ -102,7 +102,7 @@ void (async function main() {
   IPC.onDisconnected(InstanceType.sidebar, winId => {
     Logs.info('IPC.onDisconnected sidebar', winId)
 
-    if (Windows.byId[winId]) {
+    if (Settings.state.markWindow && Windows.byId[winId]) {
       browser.windows.update(winId, { titlePreface: '' })
     }
   })


### PR DESCRIPTION
I am using another extension https://github.com/irvinm/Toggle-Native-Tab-Bar which uses a similar technique to hide native tab bar by adding/removing a " " character from the window title. Closing the sidebar would make the native tab bar reappear even though the Sidebery setting to preface the window title was OFF. This change simply checks that setting before setting the window title to '' on a sidebar disconnect, just like it does on a sidebar connection. Unsure if this will affect anything downstream however.