### PR TITLE
Mark the current successor tab with [data-successor] attribute

### DIFF
--- a/src/services/tabs.fg.actions.ts
+++ b/src/services/tabs.fg.actions.ts
@@ -82,6 +82,7 @@ export function mutateNativeTabToSideberyTab(nativeTab: NativeTab): Tab {
       color: null,
       isGroup: tab.isGroup,
       preview: false,
+      isSuccessor: false
     }
   }
 
@@ -123,6 +124,7 @@ export function createReactiveProps(tab: Tab): ReactiveTabProps {
     color: null,
     isGroup: tab.isGroup,
     preview: false,
+    isSuccessor: false
   }
 
   if (reactFn) return reactFn(rProps)
@@ -2704,6 +2706,15 @@ function updateSuccession(exclude?: ID[]) {
         Logs.err('Tabs.updateSuccession: Cannot update succession:', err)
       })
       activeTab.successorTabId = target.id
+
+      // Mark the current successor tab
+      target.reactive.isSuccessor = true
+      const prevPrevActive = Tabs.byId[Tabs.successorId]
+      if (prevPrevActive) {
+        prevPrevActive.reactive.isSuccessor = false
+      }
+      Tabs.successorId = target.id
+
       return target
     }
   }

--- a/src/services/tabs.fg.ts
+++ b/src/services/tabs.fg.ts
@@ -55,6 +55,7 @@ export const Tabs = {
   removingTabs: [] as ID[],
   ignoreTabsEvents: false,
   activeId: NOID,
+  successorId: NOID,
   blockedScrollPosition: false,
   activateSelectedOnMouseLeave: false,
   sorting: false,

--- a/src/sidebar/components/tab.vue
+++ b/src/sidebar/components/tab.vue
@@ -20,6 +20,7 @@
   :data-unread="tab.reactive.unread"
   :data-edit="tab.reactive.customTitleEdit"
   :data-preview="tab.reactive.preview"
+  :data-successor="tab.reactive.isSuccessor"
   :title="tab.reactive.tooltip"
   :draggable="!tab.reactive.customTitleEdit"
   @dragstart="onDragStart"

--- a/src/types/tabs.ts
+++ b/src/types/tabs.ts
@@ -75,6 +75,7 @@ export interface ReactiveTabProps {
   customColor: string | null
   isGroup: boolean
   preview: boolean
+  isSuccessor: boolean
 }
 
 export interface InlineTabData {


### PR DESCRIPTION
This pull request is a proposed solution for https://github.com/mbnuqw/sidebery/issues/1495 

It adds `[data-successor]` attribute for a tab which is currently a successor for the current one (will be activated when the current one is closed). With the setting `Tabs > After closing current tab: previously active tab` it will add this attribute to the previously active tab, esentially replicating the "previous tab highlight" feature from the Arc browser. 

Here's an example with `Mouse > Tab actions > Activate previously active tab when clicking on the active tab (Tab flip)` enabled: 

https://github.com/user-attachments/assets/590bcaa8-167a-41dc-9071-5b76f8ef1c49

Custom CSS rule used: 
```
.Tab[data-successor="true"] .fav:before{
	content: "";
	position:absolute;
	background: var(--tabs-activated-bg);
	border-radius: var(--tabs-border-radius);
	box-shadow: var(--tabs-activated-shadow);
	outline: 1px solid lightgray;
	height: calc(16px + 10px);
	top: calc(-10px + 4px);
	width: calc(16px + 3px);
	left: -1.5px;
}
```

---

Another possible solution would be to use `[data-last-active]` attribute instead, and set it on every tab activation in [onTabActivated](https://github.com/emvaized/sidebery/blob/a21d4faba7e4ee180e9bdf1cd9a3fd429a283671/src/services/tabs.fg.handlers.ts#L1374). Probably it's a better solution to achieve the described behavior, but then it is not properly updated on tab close (newly focused tab remains with the last active attribute). 

I got the impression that marking the successor tab works more reliably for this purpose in all usage scenarios I tested: 
- on tab flip when click on the current tab
- on tab close when "activate previous tab" is enabled
- on current tab suspend