### PR TITLE
Added: option to show tab subtitle with URL

### DIFF
--- a/src/_locales/dict.setup-page.ts
+++ b/src/_locales/dict.setup-page.ts
@@ -2666,6 +2666,10 @@ Przykłady: "*", "ctrl+$", "ctrl+alt+g"`,
     zh_TW: '分頁切換間的最小延遲（毫秒）',
     ja: 'タブ切り替え間の最小遅延（ミリ秒）',
   },
+  'settings.tabs_show_subtitle': {
+    en: 'Show tab subtitle with URL',
+    ru: 'Показывать подзаголовок вкладки с URL',
+  },
 
   // - New tab position
   'settings.move_new_tab_pin': {

--- a/src/defaults/settings.ts
+++ b/src/defaults/settings.ts
@@ -90,6 +90,7 @@ export const DEFAULT_SETTINGS: SettingsState = {
   tabWarmupOnHover: true,
   tabSwitchDelay: 0,
   forceDiscard: true,
+  showTabSubtitle: false,
 
   // New tab position
   moveNewTabPin: 'start',

--- a/src/page.setup/components/settings.tabs.vue
+++ b/src/page.setup/components/settings.tabs.vue
@@ -119,6 +119,10 @@ section(ref="el")
   //-   label="settings.tab_warmup_on_hover"
   //-   v-model:value="Settings.state.tabWarmupOnHover"
   //-   @update:value="Settings.saveDebounced(150)")
+  ToggleField(
+    label="settings.tabs_show_subtitle"
+    v-model:value="Settings.state.showTabSubtitle"
+    @update:value="Settings.saveDebounced(150)")
   NumField.-inline(
     label="settings.tabs_switch_delay"
     v-model:value="Settings.state.tabSwitchDelay"

--- a/src/sidebar/components/tab.vue
+++ b/src/sidebar/components/tab.vue
@@ -69,6 +69,9 @@
         @blur="onCustomTitleBlur"
         @keydown="onCustomTitlteKD")
       .title(v-else) {{tab.reactive.customTitle ?? tab.reactive.title}}
+      .subtitle(
+        v-if="tab.reactive.url && Settings.state.showTabSubtitle"
+      ) {{ tab.reactive.url.replace(/^https?:\/\//, '') }}
     .close(
       v-if="!iconOnly && Settings.state.tabRmBtn !== 'none'"
       @mousedown.stop="onMouseDownClose"

--- a/src/styles/themes/proton/sidebar/tab.styl
+++ b/src/styles/themes/proton/sidebar/tab.styl
@@ -7,6 +7,7 @@
   --tabs-margin: var(--general-margin)
   --tabs-indent: 10px
   --tabs-font: rem(15) sans-serif
+  --tabs-subtitle-font: rem(12) sans-serif
   --tabs-count-font: rem(9) sans-serif
   --tabs-border-radius: var(--general-border-radius)
   --tabs-inner-gap: 5px
@@ -580,12 +581,13 @@
 // -- Subtitle
 // -
 .Tab .subtitle{
-	position: relative;
-  color: var(--tabs-normal-fg);
-  white-space: nowrap;
-  overflow: hidden;
-  transition: transform var(--d-fast);
-  padding-top: 1px;
+	position: relative
+  color: var(--tabs-normal-fg)
+  white-space: nowrap
+  overflow: hidden
+  transition: transform var(--d-fast)
+  font: var(--tabs-subtitle-font)
+  opacity: 0.7
 }
 
 .Tab[data-audible="true"] .t-box .subtitle,

--- a/src/styles/themes/proton/sidebar/tab.styl
+++ b/src/styles/themes/proton/sidebar/tab.styl
@@ -577,6 +577,24 @@
   color: var(--tabs-activated-fg)
 
 // ---
+// -- Subtitle
+// -
+.Tab .subtitle{
+	position: relative;
+  color: var(--tabs-normal-fg);
+  white-space: nowrap;
+  overflow: hidden;
+  transition: transform var(--d-fast);
+  padding-top: 1px;
+}
+
+.Tab[data-audible="true"] .t-box .subtitle,
+.Tab[data-muted="true"] .t-box .subtitle,
+.Tab[data-paused="true"] .t-box .subtitle{
+  transform: translateX(var(--audio-btn-offset));
+}
+
+// ---
 // -- Container highlight
 // -
 .Tab .ctx

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -89,6 +89,7 @@ export interface SettingsState {
   tabWarmupOnHover: boolean
   tabSwitchDelay: number
   forceDiscard: boolean
+  showTabSubtitle: boolean
 
   // New tab position
   moveNewTabPin: (typeof SETTINGS_OPTIONS.moveNewTabPin)[number]


### PR DESCRIPTION
This pull request adds an option to show subtitle below each tab with its URL. It probably wasn't requested by anyone, but I suddenly came up with this idea, and after test-driving it for a few days I quite liked it. Seeing all urls at once allows to navigate tabs quicker, and makes it easier to distinguish between them.

By default this option is disabled, and should be manually discovered and enabled in Sidebery settings > Tabs. Subtitle shows url of each tab, but in the future it could possibly be used to show any other information. "https://" part of the URL is trimmed in the beginning, because I found it visually overwhelming (I'm not sure if "http://" should be trimmed as well).

This PR also adds some basic styles for the subtitle, such as smaller font and 70% opacity. It could probably also include some rules to increase default tab height when subtitles are enabled, but it currently doesn't do that, so tabs might become a bit too crowded with the default tab height. 

Here's how it looks with `--tabs-height=40px` set in the styles editor (recommended): 

![2024-12-17_21-07](https://github.com/user-attachments/assets/4fa8437d-927c-4e5b-93b1-dc0255f9625e)

 