### PR TITLE
fix: search: minimum search query length in CJK should be 1.

### DIFF
--- a/src/services/search.actions.ts
+++ b/src/services/search.actions.ts
@@ -289,7 +289,12 @@ let query = ''
 let beforeSwitchingPanelId: ID | undefined
 export function search(value?: string, noSel?: boolean): void {
   if (value !== undefined) {
-    if (value.length < MIN_SEARCH_QUERY_LEN) value = ''
+    const regexCJK = /[\u4E00-\u9FFF,\u3400-\u4DBF,\u3040-\u312F,\uAC00-\uD7A3]/g
+    //CJK Unified Ideographs
+    //CJK Unified Ideographs Extension A
+    //Hiragana, Katakana, Bopomofo
+    //Hangul Syllables
+    if (value.length < MIN_SEARCH_QUERY_LEN) value = (value.match(regexCJK) === null) ? '' : value
     if (Search.reactive.value === value) return
 
     Search.prevValue = Search.reactive.value


### PR DESCRIPTION
In short, the minimum search query length required for our writing system is 1.

The reason why CJK Unified Ideographs Extension B-I are not included is because those characters are too rare... I think they can pretty much only be entered using code points directly... and therefore it is unlikely to be used for naming and searching titles.

Let's look at a simple example in Traditional Chinese:
Monday = 週一 = 星期一
Tuesday = 週二 = 星期二
Wednesday = 週三 = 星期三
Thursday = 週四 = 星期四
Friday = 週五 = 星期五
Saturday = 週六 = 星期六
Sunday = 週日 = 星期日 = 星期天
When we want to search for each day of the week, one of the situations we might want to search by just "週".