### PR TITLE
Skip favicon resize if it is a SVG containing a CSS media query

### DIFF
--- a/src/page.setup/components/popup.panel-config.vue
+++ b/src/page.setup/components/popup.panel-config.vue
@@ -606,17 +606,17 @@ function isTextFit(
   }
 }
 
-async function prepareCustomIcon(icon: string): Promise<string> {
-  state.customIconOriginal = icon
+async function prepareCustomIcon(base64icon: string): Promise<string> {
+  state.customIconOriginal = base64icon
   if (state.customIconColorize) {
     let color = RGB_COLORS[props.conf.color]
     if (props.conf.color === 'toolbar') {
       if (Styles.reactive.toolbarColorScheme === 'light') color = '#000000'
       if (Styles.reactive.toolbarColorScheme === 'dark') color = '#ffffff'
     }
-    icon = await Favicons.fillIcon(icon, color)
+    base64icon = await Favicons.fillIcon(base64icon, color)
   }
-  return await Favicons.resizeFavicon(icon)
+  return await Favicons.resizeFavicon(base64icon)
 }
 
 function openCustomIconFile(importEvent: Event) {
@@ -631,14 +631,14 @@ function openCustomIconFile(importEvent: Event) {
       return Logs.err('Cannot import data: No file content')
     }
 
-    let icon
+    let base64icon
     try {
-      icon = await prepareCustomIcon(fileEvent.target.result as string)
+      base64icon = await prepareCustomIcon(fileEvent.target.result as string)
     } catch {
       onCustomIconRm()
       return
     }
-    props.conf.iconIMG = icon
+    props.conf.iconIMG = base64icon
     props.conf.iconIMGSrc = ''
     state.customIconTextValue = ''
     state.customIconUrlValue = ''

--- a/src/services/favicons.bg.ts
+++ b/src/services/favicons.bg.ts
@@ -97,9 +97,9 @@ function getIndexToReplace(): number {
 }
 
 const saveFaviconTimeouts: Record<string, number | undefined> = {}
-export function saveFavicon(url: string, icon: string): void {
-  if (!url || !icon) return
-  if (icon.length > 234567) return
+export function saveFavicon(url: string, base64icon: string): void {
+  if (!url || !base64icon) return
+  if (base64icon.length > 234567) return
   if (url.startsWith('about')) return
 
   clearTimeout(saveFaviconTimeouts[url])
@@ -110,7 +110,7 @@ export function saveFavicon(url: string, icon: string): void {
     if (!domain) return
 
     const domainInfo: FavDomain | undefined = domainsInfo[domain]
-    const hash = Utils.strHash(icon)
+    const hash = Utils.strHash(base64icon)
 
     let index = hashes.indexOf(hash)
     const iconAlreadyExists = index > -1
@@ -145,7 +145,7 @@ export function saveFavicon(url: string, icon: string): void {
     // Resize icon
     if (!iconAlreadyExists) {
       try {
-        icon = await resizeFavicon(icon)
+        base64icon = await resizeFavicon(base64icon)
       } catch {
         return
       }
@@ -172,7 +172,7 @@ export function saveFavicon(url: string, icon: string): void {
     }
 
     // Set icon, index and hash
-    if (!iconAlreadyExists) favicons[index] = icon
+    if (!iconAlreadyExists) favicons[index] = base64icon
     hashes[index] = hash
 
     if (!iconAlreadyExists || saveAll) {
@@ -183,6 +183,6 @@ export function saveFavicon(url: string, icon: string): void {
 
     saveAll = false
 
-    IPC.sendToSidebars('setFavicon', domain, icon)
+    IPC.sendToSidebars('setFavicon', domain, base64icon)
   }, SAVE_DELAY)
 }

--- a/src/services/favicons.fg.ts
+++ b/src/services/favicons.fg.ts
@@ -87,14 +87,14 @@ let iconFillCanvas: HTMLCanvasElement | undefined
 let iconFillCanvasCtx: CanvasRenderingContext2D | null = null
 let iconFillImg: HTMLImageElement | undefined
 
-export async function fillIcon(icon: string, color: string): Promise<string> {
+export async function fillIcon(base64icon: string, color: string): Promise<string> {
   const ds = SIZE * 2
 
   if (!iconFillCanvas || !iconFillCanvasCtx) {
     iconFillCanvas = Utils.createCanvas(ds, ds)
     iconFillCanvasCtx = iconFillCanvas.getContext('2d')
     if (iconFillCanvasCtx) iconFillCanvasCtx.save()
-    else return icon
+    else return base64icon
   }
 
   if (!iconFillImg) iconFillImg = new Image()
@@ -102,18 +102,18 @@ export async function fillIcon(icon: string, color: string): Promise<string> {
   iconFillCanvasCtx.clearRect(0, 0, ds, ds)
 
   try {
-    await Utils.setImageSrc(iconFillImg, icon)
+    await Utils.setImageSrc(iconFillImg, base64icon)
   } catch {
-    return icon
+    return base64icon
   }
 
   try {
     let sw = iconFillImg.naturalWidth
     let sh = iconFillImg.naturalHeight
     if (sw === 0 || sh === 0) {
-      const svgWithSize = Utils.setSvgImageSize(icon, ds, ds)
-      if (!svgWithSize) return icon
-      await Utils.setImageSrc(iconFillImg, svgWithSize)
+      const base64svgWithSize = Utils.setSvgImageSize(base64icon, ds, ds)
+      if (!base64svgWithSize) return base64icon
+      await Utils.setImageSrc(iconFillImg, base64svgWithSize)
       sw = iconFillImg.naturalWidth
       sh = iconFillImg.naturalHeight
     }
@@ -123,11 +123,11 @@ export async function fillIcon(icon: string, color: string): Promise<string> {
     iconFillCanvasCtx.drawImage(iconFillImg, 0, 0, sw, sh, 0, 0, ds, ds)
     iconFillCanvasCtx.globalCompositeOperation = 'source-over'
   } catch (err) {
-    return icon
+    return base64icon
   }
 
-  const filledIcon = iconFillCanvas.toDataURL('image/png')
+  const filledBase64Icon = iconFillCanvas.toDataURL('image/png')
   iconFillCanvasCtx.restore()
 
-  return filledIcon
+  return filledBase64Icon
 }

--- a/src/services/favicons.ts
+++ b/src/services/favicons.ts
@@ -52,6 +52,9 @@ let favPrescaleCanvasCtx: CanvasRenderingContext2D | null = null
 let favRescaleImg: HTMLImageElement | undefined
 
 export async function resizeFavicon(base64fav: string): Promise<string> {
+  // Skip resize if fav is a SVG containing CSS Media Queries
+  if (Utils.svgImageContainsCssMediaQueries(base64fav)) return base64fav
+
   // Prescale size
   const ds = SIZE * 2
 

--- a/src/services/favicons.ts
+++ b/src/services/favicons.ts
@@ -51,7 +51,7 @@ let favRescaleCanvasCtx: CanvasRenderingContext2D | null = null
 let favPrescaleCanvasCtx: CanvasRenderingContext2D | null = null
 let favRescaleImg: HTMLImageElement | undefined
 
-export async function resizeFavicon(fav: string): Promise<string> {
+export async function resizeFavicon(base64fav: string): Promise<string> {
   // Prescale size
   const ds = SIZE * 2
 
@@ -61,25 +61,25 @@ export async function resizeFavicon(fav: string): Promise<string> {
     favRescaleCanvasCtx = favRescaleCanvas.getContext('2d')
     favPrescaleCanvasCtx = favPrescaleCanvas.getContext('2d')
   }
-  if (!favRescaleCanvasCtx || !favPrescaleCanvasCtx) return fav
+  if (!favRescaleCanvasCtx || !favPrescaleCanvasCtx) return base64fav
   if (!favRescaleImg) favRescaleImg = new Image()
 
   favRescaleCanvasCtx.clearRect(0, 0, SIZE, SIZE)
   favPrescaleCanvasCtx.clearRect(0, 0, ds, ds)
 
-  await Utils.setImageSrc(favRescaleImg, fav)
+  await Utils.setImageSrc(favRescaleImg, base64fav)
 
   try {
     let sw = favRescaleImg.naturalWidth
     let sh = favRescaleImg.naturalHeight
     if (sw === 0 || sh === 0) {
-      const svgWithSize = Utils.setSvgImageSize(fav, ds, ds)
-      if (!svgWithSize) return fav
-      await Utils.setImageSrc(favRescaleImg, svgWithSize)
+      const base64svgWithSize = Utils.setSvgImageSize(base64fav, ds, ds)
+      if (!base64svgWithSize) return base64fav
+      await Utils.setImageSrc(favRescaleImg, base64svgWithSize)
       sw = favRescaleImg.naturalWidth
       sh = favRescaleImg.naturalHeight
     }
-    if (sw === 0 || sh === 0) return fav
+    if (sw === 0 || sh === 0) return base64fav
     if (sw > ds && favPrescaleCanvas) {
       favPrescaleCanvasCtx.drawImage(favRescaleImg, 0, 0, sw, sh, 0, 0, ds, ds)
       favRescaleCanvasCtx.drawImage(favPrescaleCanvas, 0, 0, ds, ds, 0, 0, SIZE, SIZE)
@@ -87,13 +87,13 @@ export async function resizeFavicon(fav: string): Promise<string> {
       favRescaleCanvasCtx.drawImage(favRescaleImg, 0, 0, sw, sh, 0, 0, SIZE, SIZE)
     }
   } catch (err) {
-    return fav
+    return base64fav
   }
 
-  const newFav = favRescaleCanvas.toDataURL('image/png')
+  const newBase64fav = favRescaleCanvas.toDataURL('image/png')
 
-  if (newFav.length + THRESHOLD_BYTES_DIFF >= fav.length) return fav
-  else return newFav
+  if (newBase64fav.length + THRESHOLD_BYTES_DIFF >= base64fav.length) return base64fav
+  else return newBase64fav
 }
 
 export function getFavPlaceholder(url: string): string {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -732,6 +732,18 @@ export function setSvgImageSize(base64img: string, w: number, h: number): string
   return 'data:image/svg+xml;base64,' + base64
 }
 
+export function svgImageContainsCssMediaQueries(base64img: string): boolean {
+  if (!base64img.startsWith('data:image/svg+xml;base64,')) return false
+
+  let svgText
+  try {
+    svgText = atob(base64img.split(',')[1])
+  } catch {
+    return false
+  }
+  return /@media\s*\(/.test(svgText)
+}
+
 export function strHash(str: string): number {
   let hash = 0
   const len = str.length


### PR DESCRIPTION
Custom favicons can be passed as a panel icon and they can be SVGs containing dynamic CSS media queries in order to match device light mode (light or dark) for instance.

Sidebery by default redraws the favicon as a PNG, this fix skips this operation if it is a SVG containing a media query.

fixes #1937 

Note: in addition to the fix I also renamed favicon variables names in order to emphasis the fact that they are base64 images because it was not clear in the code.