### PR TITLE
Update drop status request timeout to 10000ms

### DIFF
--- a/src/services/drag-and-drop.actions.ts
+++ b/src/services/drag-and-drop.actions.ts
@@ -1293,7 +1293,7 @@ export async function onDragEnd(e: DragEvent): Promise<void> {
     }
     let consumed
     try {
-      consumed = await Utils.deadline(5000, [], Promise.all(requestingDropStatus))
+      consumed = await Utils.deadline(10000, [], Promise.all(requestingDropStatus))
     } catch (err) {
       Logs.err('DnD.onDragEnd: Cannot get drop status from other windows', err)
       return


### PR DESCRIPTION
Fixes https://github.com/mbnuqw/sidebery/issues/2038

Previously upped to 5000 from 1500 in https://github.com/mbnuqw/sidebery/commit/90c37a2d4c335aee3b68a954c86530335088da61 but appears that it needs to be further increased for large amounts of tabs/windows