### PR TITLE
Respect custom title in snapshot viewer display, export to md, open tab

### DIFF
--- a/src/page.setup/components/snapshots.tab.vue
+++ b/src/page.setup/components/snapshots.tab.vue
@@ -1,7 +1,7 @@
 <template lang="pug">
 .tab(
   draggable="true"
-  :title="tab.title"
+  :title="tab.customTitle ?? tab.title"
   :id="String(tab.id)"
   :data-folded="tab.folded"
   :data-invisible="tab.invisible"
@@ -29,7 +29,7 @@
     svg(v-else): use(:xlink:href="tab.iconSVG")
     svg.pin(v-if="tab.pinned"): use(xlink:href="#icon_pin")
   .title-url
-    .title {{tab.title}}
+    .title {{tab.customTitle ?? tab.title}}
     a.url(
       target="_blank"
       draggable="false"
@@ -156,6 +156,7 @@ async function openTab(tab: SnapTabState): Promise<void> {
     const item: ItemInfo = {
       id: tab.id ?? NOID,
       url: Snapshots.updateInternalUrl(tab.url),
+      customTitle: tab.customTitle,
       title: tab.title,
       container: tab.containerId ?? CONTAINER_ID,
     }

--- a/src/page.setup/components/snapshots.vue
+++ b/src/page.setup/components/snapshots.vue
@@ -228,6 +228,7 @@ async function openSelectedTabs(): Promise<void> {
         const item: ItemInfo = {
           id: tab.id,
           url: tab.url,
+          customTitle: tab.customTitle,
           title: tab.title,
           container: tab.containerId ?? CONTAINER_ID,
         }

--- a/src/services/snapshots.actions.ts
+++ b/src/services/snapshots.actions.ts
@@ -990,7 +990,7 @@ export function convertToMarkdown(snapshot: NormalizedSnapshot): string {
       // Normal tabs
       if (normalTabs?.length) {
         for (const tab of normalTabs) {
-          const tabLink = `[${tab.title}](${tab.url})`
+          const tabLink = `[${tab.customTitle ?? tab.title}](${tab.url})`
           md.push(tabsIndent + indent.repeat(tab.lvl ?? 0) + tabBullet + tabLink)
         }
       }


### PR DESCRIPTION
Closes https://github.com/mbnuqw/sidebery/issues/2060

For a snapshot of following tabs where both are just google.com, first with custom title Testing123:

![image](https://github.com/user-attachments/assets/9d6349ad-b140-484c-8b5d-dea6be2368b0)

Makes the snapshot viewer respect custom title in 3 ways:

1. When viewing in snapshot viewer (also hover title)

Before:

![image](https://github.com/user-attachments/assets/208150f9-4cf4-4834-84b1-9b717af94063)

After:

![image](https://github.com/user-attachments/assets/cae6e2a7-3817-4567-8d99-1066dbc93b55)

2. When exporting to markdown

Before: 

```
## Window 1
### Tabs
- [Google](https://www.google.com/)
- [Google](https://www.google.com/)
```


After: 

```
## Window 1
### Tabs
- [Testing123](https://www.google.com/)
- [Google](https://www.google.com/)
```

3. When opening new tab with custom title from snapshot viewer by clicking on it OR by selecting tabs and doing "Open in current panel"

Before: opens with normal title

After: opens with custom title, if it has one
