### PR TITLE
Normalize bundle path slash directions so building on Windows works

### DIFF
--- a/build/scripts.js
+++ b/build/scripts.js
@@ -39,7 +39,7 @@ function fixModuleImports(data) {
 }
 
 /**
- * Replace Windows-style path separators with Unix-style paths
+ * Replace Windows-style path separators (\) with Unix-style (/)
  */
 function normalizePath(p) {;
   return p.replace(/\\/g, '/')

--- a/build/scripts.js
+++ b/build/scripts.js
@@ -41,7 +41,7 @@ function fixModuleImports(data) {
 /**
  * Replace Windows-style path separators (\) with Unix-style (/)
  */
-function normalizePath(p) {;
+function normalizePath(p) {
   return p.replace(/\\/g, '/')
 }
 

--- a/build/scripts.js
+++ b/build/scripts.js
@@ -39,6 +39,13 @@ function fixModuleImports(data) {
 }
 
 /**
+ * Replace Windows-style path separators with Unix-style paths
+ */
+function normalizePath(p) {;
+  return p.replace(/\\/g, '/')
+}
+
+/**
  * Get list of .ts files
  */
 async function getSrcFiles() {
@@ -51,11 +58,22 @@ async function getSrcFiles() {
     if (!isTS && !isVUE) continue
 
     const srcPath = path.join(f.dir, f.file)
+    const normalizedSrcPath = normalizePath(srcPath)
     const outDir = path.join(OUTPUT_DIR, f.dir.replace(NORM_SRC_DIR, ''))
     const outFile = isTS ? f.file.slice(0, -3) + '.js' : f.file + '.js'
     const outPath = path.join(outDir, outFile)
 
-    result.push({ srcDir: f.dir, srcFile: f.file, srcPath, outDir, outFile, outPath, isTS, isVUE })
+    result.push({
+      srcDir: f.dir,
+      srcFile: f.file,
+      srcPath,
+      normalizedSrcPath,
+      outDir,
+      outFile,
+      outPath,
+      isTS,
+      isVUE,
+    })
   }
 
   return result
@@ -174,8 +192,8 @@ async function compileVueComponent(filePath, fileName) {
 
 async function compileTSFile(file) {
   let result
-  if (BUNDLES[file.srcPath]) {
-    const conf = BUNDLES[file.srcPath]
+  if (BUNDLES[file.normalizedSrcPath]) {
+    const conf = BUNDLES[file.normalizedSrcPath]
     await esbuild.build({
       entryPoints: [file.srcPath],
       tsconfig: 'tsconfig.json',


### PR DESCRIPTION
Closes https://github.com/mbnuqw/sidebery/issues/2078

`scripts.js#BUNDLES` uses Unix-style forward slashes for filepaths:

```
17:46:45 {
  'src/injections/group.ts': true,
  'src/injections/url.ts': true,
  'src/injections/tab-preview.ts': { format: 'iife' },
  'src/popup.tab-preview/tab-preview.ts': true
}
```

These are checked in `#compileTSFile` to determine whether to bundle or not.

But on Windows, the filepaths from `#getSrcFiles` have backslashes:

```
17:46:45 src\injections\group.ts
```

So the files aren't bundled and they can't be injected, hits `Error: import declarations may only appear at top level of a module` when trying to inject a bundled script - for example when opening a group page.

This uses the normalized Unix-style path when checking in  `#compileTSFile` which seems to resolve the issue.