### PR TITLE
Support opening Snapshots in private windows

### DIFF
--- a/src/_locales/dict.setup-page.ts
+++ b/src/_locales/dict.setup-page.ts
@@ -6814,6 +6814,9 @@ Przykłady: "*", "ctrl+$", "ctrl+alt+g"`,
     zh_TW: '開啟視窗',
     ja: 'ウィンドウを開く',
   },
+  'snapshot.btn_open_private_win': {
+    en: 'Open private window',
+  },
   'snapshot.global_pin_title': {
     en: 'Pinned tabs',
     de: 'Angeheftete Tabs',
@@ -6834,15 +6837,17 @@ Przykłady: "*", "ctrl+$", "ctrl+alt+g"`,
     zh_TW: '已選中：',
     ja: '選択中：',
   },
+  'snapshot.sel.open_in': {
+    en: 'Open in...',
+  },
   'snapshot.sel.open_in_panel': {
-    en: 'Open in current panel',
-    de: 'Im aktuellen Panel öffnen',
-    hu: 'Megnyitás a jelenlegi panelon',
-    pl: 'Otwórz w obecnym panelu',
-    ru: 'Открыть в текущей панели',
-    zh_CN: '在当前面板中打开',
-    zh_TW: '在當前面板中開啟',
-    ja: '現在のパネルで開く',
+    en: 'Current panel',
+  },
+  'snapshot.sel.open_in_window': {
+    en: 'New window',
+  },
+  'snapshot.sel.open_in_private_window': {
+    en: 'New private window',
   },
   'snapshot.sel.reset_sel': {
     en: 'Reset selection',

--- a/src/components/drop-down-button.vue
+++ b/src/components/drop-down-button.vue
@@ -16,6 +16,7 @@
 <script lang="ts" setup>
 import { ref, nextTick, onMounted, reactive } from 'vue'
 import * as Utils from 'src/utils'
+import * as Logs from 'src/services/logs'
 
 interface Props {
   label: string
@@ -74,7 +75,9 @@ async function open() {
 
   const elStyles = window.getComputedStyle(rootEl.value, null)
   let bottomPadding = parseInt(elStyles.getPropertyValue('padding-bottom'))
+  let topPadding = parseInt(elStyles.getPropertyValue('padding-top'))
   if (isNaN(bottomPadding)) bottomPadding = 0
+  if (isNaN(topPadding)) topPadding = 0
 
   await nextTick()
   if (!dropDownEl.value) return
@@ -84,12 +87,14 @@ async function open() {
 
   const viewportHeight = window.innerHeight
   const viewportWidth = window.innerWidth
+  const inputTop = Math.round(inputRect.top)
   const inputBottom = Math.round(inputRect.bottom)
   const inputRight = Math.round(inputRect.right)
 
   let dropDownTop = inputBottom - bottomPadding + 1
+
   if (viewportHeight <= dropDownTop + dropDownRect.height + bottomPadding) {
-    dropDownTop = viewportHeight - dropDownRect.height - bottomPadding
+    dropDownTop = inputTop - dropDownRect.height - topPadding - 1
   }
 
   if (viewportWidth < dropDownRect.width + (viewportWidth - inputRight)) {

--- a/src/page.setup/components/snapshots.vue
+++ b/src/page.setup/components/snapshots.vue
@@ -43,7 +43,8 @@
                 svg.exp-icon: use(xlink:href="#icon_expand")
               .win-name {{translate('snapshot.window_title') + ' ' + (i + 1)}}
               .win-len ({{win.tabsLen}} {{translate('snapshot.snap_tab', win.tabsLen)}})
-              .btn(@click="openWindow(state.activeSnapshot, i)") {{translate('snapshot.btn_open_win')}}
+              .btn(@click="openWindow(state.activeSnapshot, i, false)") {{translate('snapshot.btn_open_win')}}
+              .btn(@click="openWindow(state.activeSnapshot, i, true)") {{translate('snapshot.btn_open_private_win')}}
             .panels(v-show="!win.folded")
               .panel(v-for="panel in win.panels" :key="panel.id" :data-void="panel.id === -1")
                 .panel-bar(:data-color="panel.color" :data-folded="panel.folded")
@@ -65,7 +66,14 @@
                     :viewerState="state")
       .selection-bar(:data-active="!!selectedTabsLen")
         .info {{translate('snapshot.selected')}} {{selectedTabsLen}}
-        .btn(@click="openSelectedTabs()") {{translate('snapshot.sel.open_in_panel')}}
+        DropDownButton(
+          :label="translate('snapshot.sel.open_in')")
+          a(@click="openSelectedTabs(SnapOpenType.NEW_WINDOW)").snapshot-export-opt
+            .label {{translate('snapshot.sel.open_in_window')}}
+          a(@click="openSelectedTabs(SnapOpenType.NEW_PRIVATE_WINDOW)").snapshot-export-opt
+            .label {{translate('snapshot.sel.open_in_private_window')}}
+          a(@click="openSelectedTabs(SnapOpenType.CURRENT_PANEL)").snapshot-export-opt
+            .label {{translate('snapshot.sel.open_in_panel')}}
         .btn(@click="resetSelection()") {{translate('snapshot.sel.reset_sel')}}
 
     .placeholder(v-if="!state.snapshots.length")
@@ -76,10 +84,19 @@
 </template>
 
 <script lang="ts" setup>
-import { reactive, computed, nextTick } from 'vue'
+import { computed, nextTick, reactive } from 'vue'
 import * as Utils from 'src/utils'
-import { Stored, Snapshot, SnapshotState, RemovingSnapshotResult } from 'src/types'
-import { SnapTabState, ItemInfo, NormalizedSnapshot, SnapExportInfo } from 'src/types'
+import {
+  ItemInfo,
+  NormalizedSnapshot,
+  RemovingSnapshotResult,
+  SnapExportInfo,
+  SnapOpenType,
+  Snapshot,
+  SnapshotState,
+  SnapTabState,
+  Stored,
+} from 'src/types'
 import { CONTAINER_ID } from 'src/defaults'
 import { translate } from 'src/dict'
 import * as IPC from 'src/services/ipc'
@@ -211,7 +228,7 @@ function onClick() {
   state.mouseUpShiftMode = true
 }
 
-async function openSelectedTabs(): Promise<void> {
+async function openSelectedTabs(how: SnapOpenType): Promise<void> {
   if (!state.activeSnapshot) return
 
   const items: ItemInfo[] = []
@@ -244,25 +261,29 @@ async function openSelectedTabs(): Promise<void> {
     }
   }
 
-  const activePanel = await IPC.sidebar(Windows.id, 'getActivePanelConfig')
-  if (Utils.isTabsPanel(activePanel)) {
-    await IPC.sidebar(Windows.id, 'openTabs', items, { panelId: activePanel.id })
-  } else {
-    for (const item of items) {
-      const conf: browser.tabs.CreateProperties = {
-        url: Utils.normalizeUrl(item.url, item.title),
-        windowId: Windows.id,
-        active: false,
-        cookieStoreId: item.container,
-      }
-      if (conf.url && !conf.url.startsWith('a') && item.title) {
-        conf.discarded = true
-        conf.title = item.title
-        conf.active = false
-      }
+  if (how == SnapOpenType.CURRENT_PANEL) {
+    const activePanel = await IPC.sidebar(Windows.id, 'getActivePanelConfig')
+    if (Utils.isTabsPanel(activePanel)) {
+      await IPC.sidebar(Windows.id, 'openTabs', items, { panelId: activePanel.id })
+    } else {
+      for (const item of items) {
+        const conf: browser.tabs.CreateProperties = {
+          url: Utils.normalizeUrl(item.url, item.title),
+          windowId: Windows.id,
+          active: false,
+          cookieStoreId: item.container,
+        }
+        if (conf.url && !conf.url.startsWith('a') && item.title) {
+          conf.discarded = true
+          conf.title = item.title
+          conf.active = false
+        }
 
-      browser.tabs.create(conf)
+        await browser.tabs.create(conf)
+      }
     }
+  } else {
+    await Windows.createWithTabs(items, { incognito: how == SnapOpenType.NEW_PRIVATE_WINDOW })
   }
 }
 
@@ -282,13 +303,17 @@ async function openAllWindows(snapshot: SnapshotState | null): Promise<void> {
   }
 }
 
-async function openWindow(snapshot: SnapshotState | null, winIndex: number): Promise<void> {
+async function openWindow(
+  snapshot: SnapshotState | null,
+  winIndex: number,
+  incognito: boolean
+): Promise<void> {
   if (!snapshot) return
 
   const normSnapshot = Snapshots.snapshotStateToNormalizedSnapshot(snapshot)
 
   try {
-    await IPC.bg('openSnapshotWindows', normSnapshot, winIndex)
+    await IPC.bg('openSnapshotWindows', normSnapshot, winIndex, incognito)
   } catch (err) {
     Logs.err('Snapshots: Cannot openWindow', err)
   }

--- a/src/services/snapshots.actions.ts
+++ b/src/services/snapshots.actions.ts
@@ -551,7 +551,11 @@ async function adaptTabsPanels(snapshot: NormalizedSnapshot): Promise<void> {
 /**
  * Open windows (all or by index) of snapshot
  */
-export async function openWindows(snapshot: NormalizedSnapshot, winIndex?: number): Promise<void> {
+export async function openWindows(
+  snapshot: NormalizedSnapshot,
+  winIndex?: number,
+  incognito: boolean = false
+): Promise<void> {
   Logs.info('Snapshots.openWindows')
 
   // Adapt containers
@@ -563,17 +567,21 @@ export async function openWindows(snapshot: NormalizedSnapshot, winIndex?: numbe
   // Open windows
   if (winIndex === undefined) {
     for (let i = 0; i < snapshot.tabs.length; i++) {
-      await openWindow(snapshot, i)
+      await openWindow(snapshot, i, incognito)
     }
   } else {
-    await openWindow(snapshot, winIndex)
+    await openWindow(snapshot, winIndex, incognito)
   }
 }
 
 /**
  * Open window of snapshot
  */
-async function openWindow(snapshot: NormalizedSnapshot, winIndex: number): Promise<void> {
+async function openWindow(
+  snapshot: NormalizedSnapshot,
+  winIndex: number,
+  incognito: boolean = false
+): Promise<void> {
   Logs.info('Snapshots.openWindow')
 
   const winTabs = snapshot.tabs[winIndex]
@@ -622,7 +630,7 @@ async function openWindow(snapshot: NormalizedSnapshot, winIndex: number): Promi
   const firstItem = items[0]
   if (firstItem) firstItem.active = true
 
-  await Windows.createWithTabs(items, { incognito: false })
+  await Windows.createWithTabs(items, { incognito: incognito })
 }
 
 function limitSnapshots(snapshots: Snapshot[]): Snapshot[] | undefined {

--- a/src/styles/themes/proton/page.setup/snapshots.styl
+++ b/src/styles/themes/proton/page.setup/snapshots.styl
@@ -348,6 +348,7 @@
   .btn
     font-size: rem(14)
     padding: 3px 8px
+    margin: 0 8px 0 0
 
 .Snapshots .win-icon
   position: relative
@@ -696,6 +697,13 @@ for i in 1..12
 
 .Snapshots .selection-bar .btn
   margin: 0 8px 0 0
+  padding: 3px 8px
+  font-size: rem(14)
+
+.Snapshots .selection-bar .DropDownButton
+  margin: 0 8px 0 0
+
+.Snapshots .selection-bar .DropDownButton .body
   padding: 3px 8px
   font-size: rem(14)
 

--- a/src/types/snapshots.ts
+++ b/src/types/snapshots.ts
@@ -74,6 +74,12 @@ export const enum RemovingSnapshotResult {
   Err = -1,
 }
 
+export const enum SnapOpenType {
+  CURRENT_PANEL = 1,
+  NEW_WINDOW,
+  NEW_PRIVATE_WINDOW,
+}
+
 export interface SnapExportTypes {
   JSON?: boolean
   Markdown?: boolean


### PR DESCRIPTION
I've been getting annoyed that snapshots can't easily be opened in private windows, even if the tabs were initially in a private window. At the moment a user has to open a private window manually and then select to open tabs in the current panel. This change gives the option to open windows in a private window, or open tabs in either the current panel, a new window, or a private window. Preferably the snapshot itself would also maintain the incognito state, which I'd also like to do, but that seemed like a much bigger change that I haven't explored fully yet.