### PR TITLE
fix: Search popup sometimes not focusing

### DIFF
--- a/src/popup.search/search.ts
+++ b/src/popup.search/search.ts
@@ -10,6 +10,12 @@ const el = document.getElementById('textInput') as HTMLInputElement
 
 el?.focus()
 
+for (let i = 0; i <= 500; i += 100) {
+  setTimeout(() => {
+    el?.focus()
+  }, i)
+}
+
 el?.addEventListener('blur', () => {
   if (Windows.id !== undefined) IPC.sendToSidebar(Windows.id, 'onOutsideSearchExit')
 })
@@ -92,6 +98,7 @@ void (async () => {
   IPC.setInstanceType(InstanceType.search)
   IPC.setupGlobalMessageListener()
   IPC.registerActions({ closePopup })
+  
   const [win] = await Promise.all([
     browser.windows.getCurrent({ populate: false }),
     Settings.loadSettings(),

--- a/src/popup.search/search.ts
+++ b/src/popup.search/search.ts
@@ -10,7 +10,7 @@ const el = document.getElementById('textInput') as HTMLInputElement
 
 el?.focus()
 
-for (let i = 0; i <= 500; i += 100) {
+for (let i = 0; i <= 1000; i += 100) {
   setTimeout(() => {
     el?.focus()
   }, i)

--- a/src/services/search.actions.ts
+++ b/src/services/search.actions.ts
@@ -14,24 +14,17 @@ import { Windows } from './windows'
 import { History } from './history'
 import { Bookmarks } from './bookmarks'
 import * as Selection from './selection'
-
-export const INPUT_TIMEOUT = 300
-
 export function init(): void {
   if (Settings.state.searchBarMode === 'static') Search.reactive.barIsShowed = true
 }
 
-let inputTimeout: number | undefined
 export function onOutsideSearchInput(value: string): void {
   if (!Windows.focused) return
   if (!Search.reactive.barIsShowed && Search.rawValue) Search.toggleBar()
 
   Search.reactive.rawValue = Search.rawValue = value
 
-  clearTimeout(inputTimeout)
-  inputTimeout = setTimeout(() => {
-    Search.search(Search.rawValue)
-  }, INPUT_TIMEOUT)
+  Search.search(Search.rawValue)
 }
 
 export function onOutsideSearchExit(): void {
@@ -441,8 +434,9 @@ export function start(): void {
     // Reset browser action
     setTimeout(() => browser.browserAction.setPopup({ popup: null }), 500)
   }
-
-  showBar()
+  else {
+    showBar()
+  }
 }
 
 export function close(): void {


### PR DESCRIPTION
Fixed #1810. It seems to focus mostly consistently for me now. I've still had a handful of cases where it still didn't focus, however it seems to work much better than the current version.

Changes in this PR:
- Try to focus the element 10 times in the first second
- Sidebery's default search bar now only shows when in focus of sidebery. Previously, it would show it even when sidebery was not in focus. I believe this primarily led to the issue, as I suppose the search window of sidebery also tried to get focus, which conflicted.
- Removed the 300ms delay for search. Not sure why this is a thing in the first place, it works perfectly fine without the delay and is much more snappier and usable, especially when using this feature a lot and frequently switching between tabs. 