### PR TITLE
Update Firefox-Styles-Snippets-(via-userChrome.css).md

### DIFF
--- a/docs/wiki/Firefox-Styles-Snippets-(via-userChrome.css).md
+++ b/docs/wiki/Firefox-Styles-Snippets-(via-userChrome.css).md
@@ -169,4 +169,8 @@ ln -fs chrome/firefox-gnome-theme/configuration/user.js user.js
 }
 ```
 
-7. Restart Firefox.
+7. If desired, hide sidebar revamp (the part with Firefox tools)
+
+Set `sidebar.revamp` to `false` in about:config.
+
+8. Restart Firefox.


### PR DESCRIPTION
Added step to additionally hide the 'revamped sidebar' with Firefox tools. The instructions before this addition left a sidebar further to the side of Sidebery.