### PR TITLE
l10n: don’t concatenate translation strings, use more source strings

### DIFF
--- a/src/_locales/dict.setup-page.ts
+++ b/src/_locales/dict.setup-page.ts
@@ -130,7 +130,7 @@ export const setupPageTranslations: Translations = {
   'container.rules_include_tooltip': {
     en: 'Reopen tabs with matched URLs in this container.\nNewline separated list of "substrings" or "/regex/":\n    example.com\n    /^(some)?regex$/\n    ...',
     de: 'Tabs mit passender URL in dieser Umgebung neu öffnen.\nMit Zeilenumsprüngen getrennte Liste von "Zeichenketten" oder "/RegEx/":\n    example.com\n    /^(some)?regex$/\n    ...',
-    fr: 'Rouvrir les onglets dont l’URL correspond dans ce conteneur.\nListe de “sous-chaine” ou “/RegExp/” avec une entrée par ligne:\n    example.com\n    /^(une)?regex$/\n    …',
+    fr: 'Rouvrir les onglets dont l’URL correspond dans ce conteneur.\nListe de “sous-chaines” ou “/RegExp/” avec une entrée par ligne:\n    example.com\n    /^(une)?regex$/\n    …',
     hu: 'Az illeszkedő URL-ek újranyitása ebben a konténerben.\nSoronként egy-egy "szövegrészlet" vagy /RegExp/:\n    pelda.hu\n    /^(szabályos)?kifejezés$/\n    …',
     pl: 'Otwórz ponownie karty z pasującymi URL w tym kontenerze.\nLista "substrings" lub "/regex/ oddzielona nowymi liniami:\n    example.com\n    /^(some)?regex$/\n    ...',
     ru: 'Переоткрывать вкладки с совпадающими url в этом контейнере.\nПострочный список правил "substrings" или "/regex/":\n    example.com\n    /^(some)?regex$/\n    ...',
@@ -155,7 +155,7 @@ export const setupPageTranslations: Translations = {
     en: 'Reopen tabs with matched URL in default container.\nNewline separated list of "substrings" or "/regex/":\n    example.com\n    /^(some)?regex$/\n    ...',
     de: 'Tabs mit passender URL in Standardumgebung neu öffnen.\nMit Zeilenumsprüngen getrennte Liste von "Zeichenketten" oder "/RegEx/":\n    example.com\n    /^(some)?regex$/\n    ...',
     fr: `Rouvrir les onglets dont l’URL correspond dans le conteneur par défaut.
-Liste de “sous-chaine” ou “/RegExp/” avec une entrée par ligne:
+Liste de “sous-chaines” ou “/RegExp/” avec une entrée par ligne:
     example.com
     /^(une)?regex$/\n
     …`,
@@ -1950,49 +1950,34 @@ Available variables: %B - a list mark (bullet); %CT - custom title or title; %T 
     zh_TW: '設定',
     ja: '設定',
   },
-  'settings.nav_rm_tabs_panel_confirm_pre': {
-    en: 'Delete "',
-    de: 'Lösche "',
-    fr: 'Supprimer le panneau “',
-    hu: 'Törölhető a panel: „',
-    pl: 'Usunąć panel "',
-    ru: 'Удалить панель "',
-    zh_CN: '删除 "',
-    zh_TW: '刪除「',
-    ja: '「',
+  'settings.nav_rm_tabs_panel_confirm': {
+    en: name =>
+      `Delete "${name}" panel?\nAll tabs of this panel will be assigned to nearest tabs panel.`,
+    de: name =>
+      `Lösche "${name}" Panel?\nAlle Tabs dieses Panels werden dem nächsten Tab-Panel zugeordnet.`,
+    fr: name =>
+      `Supprimer le panneau “${name}”?\nTous les onglets de ce panneau seront assignés au panneau d’onglets le plus proche.`,
+    hu: name =>
+      `Törölhető a panel: „${name}”?\nA panel minden lapja átkerül a legközelebbi lappanelra.`,
+    pl: name =>
+      `Usunąć panel "${name}"?\nWszystkie karty z tego panelu zostaną przypisane do najbliższego panelu kart.`,
+    ru: name =>
+      `Удалить панель "${name}"?\n Все вкладки этой панели будут присоединены к соседней панели.`,
+    zh_CN: name => `删除 "${name}" 面板吗？\n此面板的全部标签页都将分配给最近的标签页面板。`,
+    zh_TW: name => `刪除「${name}」面板嗎？\n該面板的全部分頁都將分配給最靠近的分頁面板。`,
+    ja: name =>
+      `「${name}」パネルを削除しますか？\nこのパネルのすべてのタブは、最も近いタブパネルに割り当てられます。`,
   },
-  'settings.nav_rm_tabs_panel_confirm_post': {
-    en: '" panel?\nAll tabs of this panel will be assigned to nearest tabs panel.',
-    de: '" Panel?\nAlle Tabs dieses Panels werden dem nächsten Tab-Panel zugeordnet.',
-    fr: '”?\nTous les onglets de ce panneau seront assignés au panneau d’onglets le plus proche.',
-    hu: '”?\nA panel minden lapja átkerül a legközelebbi lappanelra.',
-    pl: '"?\nWszystkie karty z tego panelu zostaną przypisane do najbliższego panelu kart.',
-    ru: '"?\n Все вкладки этой панели будут присоединены к соседней панели.',
-    zh_CN: '" 面板吗？\n此面板的全部标签页都将分配给最近的标签页面板。',
-    zh_TW: '」面板嗎？\n該面板的全部分頁都將分配給最靠近的分頁面板。',
-    ja: '」パネルを削除しますか？\nこのパネルのすべてのタブは、最も近いタブパネルに割り当てられます。',
-  },
-  'settings.nav_rm_bookmarks_panel_confirm_pre': {
-    en: 'Delete "',
-    de: 'Lösche "',
-    fr: 'Supprimer le panneau “',
-    hu: 'Törölhető a panel: „',
-    pl: 'Usunąć panel ',
-    ru: 'Удалить панель "',
-    zh_CN: '删除 "',
-    zh_TW: '刪除「',
-    ja: '「',
-  },
-  'settings.nav_rm_bookmarks_panel_confirm_post': {
-    en: '" panel?',
-    de: '" Panel?',
-    fr: '”?',
-    hu: '”?',
-    pl: '"?',
-    ru: '"?',
-    zh_CN: '" 面板吗？',
-    zh_TW: '」面板嗎？',
-    ja: '」パネルを削除しますか？',
+  'settings.nav_rm_bookmarks_panel_confirm': {
+    en: name => `Delete "${name}" panel?`,
+    de: name => `Lösche "${name}" Panel?`,
+    fr: name => `Supprimer le panneau “${name}”?`,
+    hu: name => `Törölhető a panel: „${name}”?`,
+    pl: name => `Usunąć panel ${name}"?`,
+    ru: name => `Удалить панель "${name}"?`,
+    zh_CN: name => `删除 "${name}" 面板吗？`,
+    zh_TW: name => `刪除「${name}」面板嗎？`,
+    ja: name => `「${name}」パネルを削除しますか？`,
   },
 
   // - Group page
@@ -2062,27 +2047,16 @@ Available variables: %B - a list mark (bullet); %CT - custom title or title; %T 
     zh_TW: '依名稱排序容器',
     ja: '名前でコンテナをソート',
   },
-  'settings.contianer_remove_confirm_prefix': {
-    en: 'Are you sure you want to delete "',
-    de: 'Möchten Sie die Umgebung "',
-    fr: 'Voulez-vous vraiment supprimer le conteneur “',
-    hu: 'Biztos törölhető a konténer: „',
-    pl: 'Jesteś pewny, że chcesz usunąć kontener "',
-    ru: 'Вы действительно хотите удалить контейнер "',
-    zh_CN: '您确定要删除 "',
-    zh_TW: '您確定要刪除「',
-    ja: '「',
-  },
-  'settings.contianer_remove_confirm_postfix': {
-    en: '" container?',
-    de: '" wirklich löschen?',
-    fr: '”?',
-    hu: '”?',
-    pl: '"?',
-    ru: '"?',
-    zh_CN: '" 容器吗？',
-    zh_TW: '」容器嗎？',
-    ja: '」コンテナを削除しますか？',
+  'settings.container_remove_confirm': {
+    en: name => `Are you sure you want to delete "${name}" container?`,
+    de: name => `Möchten Sie die Umgebung "${name}" wirklich löschen?`,
+    fr: name => `Voulez-vous vraiment supprimer le conteneur “${name}”?`,
+    hu: name => `Biztos törölhető a konténer: „${name}”?`,
+    pl: name => `Jesteś pewny, że chcesz usunąć kontener "${name}"?`,
+    ru: name => `Вы действительно хотите удалить контейнер "${name}"?`,
+    zh_CN: name => `您确定要删除 "${name}" 容器吗？`,
+    zh_TW: name => `您確定要刪除「${name}」容器嗎？`,
+    ja: name => `「${name}」コンテナを削除しますか？`,
   },
   'settings.containers_create_btn': {
     en: 'Create container',

--- a/src/_locales/dict.sidebar.ts
+++ b/src/_locales/dict.sidebar.ts
@@ -29,27 +29,22 @@ export const sidebarTranslations: Translations = {
     zh: '警告',
     ja: '警告',
   },
-  'confirm.tabs_close_pre': {
-    en: 'Are you sure you want to close ',
-    de: 'Möchten Sie diese ',
-    fr: 'Voulez-vous vraiment fermer ',
-    hu: 'Biztosan bezárható a lap: „',
-    pl: 'jesteś pewnien, że chcesz zamknąć karty ',
-    ru: 'Вы действительно хотите закрыть ',
-    zh_CN: '您确定要关闭 ',
-    zh_TW: '您確定要關閉 ',
-    ja: '本当に閉じますか',
-  },
-  'confirm.tabs_close_post': {
-    en: ' tabs?',
-    de: ' Tabs wirklich schließen?',
-    fr: ' onglets?',
-    hu: '”?',
-    pl: '?',
-    ru: (n = 0) => (NUM_234_RE.test(n.toString()) ? ' вкладки?' : ' вкладок?'),
-    zh_CN: ' 标签页吗？',
-    zh_TW: ' 分頁嗎？',
-    ja: 'のタブを閉じますか？',
+  'confirm.tabs_close': {
+    en: n => `Are you sure you want to close ${n} tabs?`,
+    de: n => `Möchten Sie diese ${n} Tabs wirklich schließen?`,
+    fr: n =>
+      n === 1
+        ? `Voulez-vous vraiment fermer un onglet?`
+        : `Voulez-vous vraiment fermer ${n} onglets?`,
+    hu: n => `Biztosan bezárható a lap: „${n}”?`,
+    pl: n => `jesteś pewnien, że chcesz zamknąć karty ${n}?`,
+    ru: n =>
+      NUM_234_RE.test(n.toString())
+        ? `Вы действительно хотите закрыть ${n} вкладки?`
+        : `Вы действительно хотите закрыть ${n} вкладок?`,
+    zh_CN: n => `您确定要关闭 ${n} 标签页吗？`,
+    zh_TW: n => `您確定要關閉 ${n} 分頁嗎？`,
+    ja: n => `本当に閉じますか${n}のタブを閉じますか？`,
   },
   'confirm.bookmarks_delete': {
     en: 'Are you sure you want to delete selected bookmarks?',
@@ -128,40 +123,23 @@ export const sidebarTranslations: Translations = {
     zh_TW: '開啟一個新分頁',
     ja: '新しいタブを開く',
   },
-  'newTabBar.in_default_container': {
-    en: ' in default container',
-    de: ' in der Standardumgebung',
-    fr: ' dans le conteneur par défaut',
-    hu: ' az alapértelmezett konténerben',
-    pl: ' w domyślnym kontenerze',
-    ru: ' в стандартном контейнере',
-    zh_CN: ' 在默认容器中',
-    zh_TW: ' 在預設容器中',
-    ja: 'デフォルトのコンテナで',
+  'newTabBar.new_tab_in_container': {
+    en: name => `Open a new tab in "${name}" container`,
+    de: name => `Öffne einen neuen Tab in der Umgebung "${name}"`,
+    fr: name => `Ouvrir un nouvel onglet dans le conteneur “${name}”`,
+    hu: name => `Új lap ebben a konténerben: „${name}”`,
+    pl: name => `Otwórz nową kartę w kontenerze "${name}"`,
+    ru: name => `Открыть новую вкладку в контейнере "${name}"`,
   },
-  'newTabBar.in_container_prefix': {
-    en: ' in "',
-    de: ' in der Umgebung "',
-    fr: ' dans le conteneur “',
-    hu: ' ebben a konténerben: „',
-    pl: ' w kontenerze "',
-    ru: ' в контейнере "',
-    zh_CN: ' 在 "',
-    zh_TW: ' 在「',
-    ja: '「',
+  'newTabBar.new_tab_in_default_container_with_url': {
+    en: url => `Open "${url}" in a new tab`,
+    fr: url => `Ouvrir “${url}” dans un nouvel onglet`,
   },
-  'newTabBar.in_container_postfix': {
-    en: '" container',
-    de: '"',
-    fr: '”',
-    hu: '”',
-    pl: '"',
-    ru: '"',
-    zh_CN: '" 容器中',
-    zh_TW: '」容器中',
-    ja: '」コンテナ',
+  'newTabBar.new_tab_in_container_with_url': {
+    en: (url, name) => `Open "${url}" in a new tab in "${name}" container`,
+    fr: (url, name) => `Ouvrir “${url}” dans un nouvel onglet dans le conteneur “${name}”`,
   },
-  'newTabBar.mid_child': {
+  'newTabBar.open_child_tab_in_default_container': {
     en: 'Middle click: Open a child tab',
     de: 'Mittelklick: Öffne einen untergeordneten Tab',
     fr: 'Clic milieu: Ouvrir un onglet enfant',
@@ -172,8 +150,21 @@ export const sidebarTranslations: Translations = {
     zh_TW: '中鍵點選：開啟子分頁',
     ja: '中クリック：子タブを開く',
   },
-  'newTabBar.mid_reopen': {
-    en: 'Middle click: Reopen active tab',
+  'newTabBar.open_child_tab_in_default_container_with_url': {
+    en: url => `Middle click: Open "${url}" in a child tab`,
+    fr: url => `Clic milieu: Ouvrir “${url}” dans un onglet enfant`,
+  },
+  'newTabBar.open_child_tab_in_container': {
+    en: name => `Middle click: Open a child tab in "${name}" container`,
+    fr: name => `Clic milieu: Ouvrir un onglet enfant dans le conteneur “${name}”`,
+  },
+  'newTabBar.open_child_tab_in_container_with_url': {
+    en: (url, name) => `Middle click: Open "${url}" in a child tab in "${name}" container`,
+    fr: (url, name) =>
+      `Clic milieu: Ouvrir “${url}” dans un onglet enfant dans le conteneur “${name}”`,
+  },
+  'newTabBar.middle_click_reopen_active_tab_in_default_container': {
+    en: 'Middle click: Reopen active tab in default container',
     de: 'Mittelklick: Aktiven Tab erneut öffnen',
     fr: "Clic milieu: rouvrir l'onglet actif",
     hu: 'Középső kattintás: az aktív lap újranyitása',
@@ -182,6 +173,19 @@ export const sidebarTranslations: Translations = {
     zh_CN: '中键点击：重新打开活动标签页',
     zh_TW: '中鍵點選：重新開啟當前分頁',
     ja: '中クリック：アクティブタブを再度開く',
+  },
+  'newTabBar.middle_click_reopen_active_tab_in_default_container_with_url': {
+    en: url => `Middle click: Load "${url}" in active tab`,
+    fr: url => `Clic milieu: Charger “${url}” dans l’onglet actif`,
+  },
+  'newTabBar.middle_click_reopen_active_tab_in_container': {
+    en: name => `Middle click: Reopen active tab in "${name}" container`,
+    fr: name => `Clic milieu: Rouvrir l’onglet actif dans le conteneur “${name}”`,
+  },
+  'newTabBar.middle_click_reopen_active_tab_in_container_with_url': {
+    en: (url, name) => `Middle click: Load "${url}" in active tab in "${name}" container`,
+    fr: (url, name) =>
+      `Clic milieu: Charger “${url}” dans l’onglet actif dans le conteneur “${name}”`,
   },
 
   // ---

--- a/src/page.setup/components/settings.containers.vue
+++ b/src/page.setup/components/settings.containers.vue
@@ -80,9 +80,7 @@ async function createContainer(): Promise<void> {
  * Remove container
  */
 async function removeContainer(container: Container): Promise<void> {
-  let preMsg = translate('settings.contianer_remove_confirm_prefix')
-  let postMsg = translate('settings.contianer_remove_confirm_postfix')
-  if (window.confirm(preMsg + container.name + postMsg)) {
+  if (window.confirm(translate('settings.container_remove_confirm', container.name))) {
     let navSaveNeeded = false
     try {
       await browser.contextualIdentities.remove(container.id)

--- a/src/page.setup/components/settings.navbar.vue
+++ b/src/page.setup/components/settings.navbar.vue
@@ -321,13 +321,9 @@ function disableBtn(index: number): void {
 function getRmConfirmMsg(panel: PanelConfig): string | undefined {
   if (!panel.name) return
   if (Utils.isTabsPanel(panel)) {
-    let preMsg = translate('settings.nav_rm_tabs_panel_confirm_pre')
-    let postMsg = translate('settings.nav_rm_tabs_panel_confirm_post')
-    return preMsg + panel.name + postMsg
+    return translate('settings.nav_rm_tabs_panel_confirm', panel.name)
   } else if (Utils.isBookmarksPanel(panel)) {
-    let preMsg = translate('settings.nav_rm_bookmarks_panel_confirm_pre')
-    let postMsg = translate('settings.nav_rm_bookmarks_panel_confirm_post')
-    return preMsg + panel.name + postMsg
+    return translate('settings.nav_rm_bookmarks_panel_confirm', panel.name)
   }
 }
 

--- a/src/services/tabs.fg.rm.ts
+++ b/src/services/tabs.fg.rm.ts
@@ -241,9 +241,7 @@ export async function removeTabs(
     Settings.state.warnOnMultiTabClose === 'any' ||
     (hasInvisibleTab && Settings.state.warnOnMultiTabClose === 'collapsed')
   if (!silent && warn && count > 1) {
-    const pre = translate('confirm.tabs_close_pre', count)
-    const post = translate('confirm.tabs_close_post', count)
-    const ok = await Popups.confirm(pre + String(count) + post)
+    const ok = await Popups.confirm(translate('confirm.tabs_close', count))
     if (!ok) {
       let visTabsRecalcNeeded = false
       tabs.forEach(t => {

--- a/src/sidebar/components/bar.new-tab.vue
+++ b/src/sidebar/components/bar.new-tab.vue
@@ -148,28 +148,46 @@ const btns = computed<NewTabBtn[]>(() => {
 })
 
 function createTooltip(btn: NewTabBtn): string {
-  let tooltip = translate('newTabBar.new_tab')
-  if (btn.containrtName) {
-    tooltip +=
-      translate('newTabBar.in_container_prefix') +
-      btn.containrtName +
-      translate('newTabBar.in_container_postfix')
-  }
-  if (btn.url) tooltip += ': ' + btn.url
+  const newTabMiddleClickOpenNewChild = Settings.state.newTabMiddleClickAction === 'new_child'
+  let tooltip = null
 
-  if (Settings.state.newTabMiddleClickAction === 'new_child') {
-    tooltip += '\n' + translate('newTabBar.mid_child')
-  } else {
-    tooltip += '\n' + translate('newTabBar.mid_reopen')
-    if (btn.containrtName) {
-      tooltip +=
-        translate('newTabBar.in_container_prefix') +
-        btn.containrtName +
-        translate('newTabBar.in_container_postfix')
-    } else if (!btn.url) {
-      tooltip += translate('newTabBar.in_default_container')
+  if (btn.containrtName) {
+    if (btn.url) {
+      tooltip =
+        translate('newTabBar.new_tab_in_container_with_url', btn.url, btn.containrtName) + '\n'
+      tooltip += translate(
+        newTabMiddleClickOpenNewChild
+          ? 'newTabBar.open_child_tab_in_container_with_url'
+          : 'newTabBar.middle_click_reopen_active_tab_in_container_with_url',
+        btn.url,
+        btn.containrtName
+      )
+    } else {
+      tooltip = translate('newTabBar.new_tab_in_container', btn.containrtName) + '\n'
+      tooltip += translate(
+        newTabMiddleClickOpenNewChild
+          ? 'newTabBar.open_child_tab_in_container'
+          : 'newTabBar.middle_click_reopen_active_tab_in_container',
+        btn.containrtName
+      )
     }
-    if (btn.url) tooltip += ': ' + btn.url
+  } else {
+    if (btn.url) {
+      tooltip = translate('newTabBar.new_tab_in_default_container_with_url', btn.url) + '\n'
+      tooltip += translate(
+        newTabMiddleClickOpenNewChild
+          ? 'newTabBar.open_child_tab_in_default_container_with_url'
+          : 'newTabBar.middle_click_reopen_active_tab_in_default_container_with_url',
+        btn.url
+      )
+    } else {
+      tooltip = translate('newTabBar.new_tab') + '\n'
+      tooltip += translate(
+        newTabMiddleClickOpenNewChild
+          ? 'newTabBar.open_child_tab_in_default_container'
+          : 'newTabBar.middle_click_reopen_active_tab_in_default_container'
+      )
+    }
   }
 
   return tooltip


### PR DESCRIPTION
Fixes part of #2170.

I totally eliminated the complicated logic around the tooltips for new tab buttons and instead created a bunch of strings to cover each case and greatly ease translatability (the strings are slightly different because I harmonized them a little bit).

Otherwise, it’s all pretty obvious stuff, and I did my best to not alter current behavior.