### PR TITLE
Fix: onKeySwitchToPrevPanel() should switch instead of only activate

### DIFF
--- a/src/services/keybindings.ts
+++ b/src/services/keybindings.ts
@@ -319,7 +319,7 @@ function onKeySwitchToPrevPanel() {
   const prevPanel = Sidebar.panelsById[Sidebar.prevActivePanelId]
   if (!prevPanel) return
 
-  Sidebar.activatePanel(Sidebar.prevActivePanelId)
+  Sidebar.switchToPanel(Sidebar.prevActivePanelId, false, true)
 }
 
 function onKeyCopyUrl() {


### PR DESCRIPTION
# Fix: onKeySwitchToPrevPanel() should switch instead of only activate

In the "Switching between panels" settings, only "Switch to previously active panel" seems activate the destination panel, rather than switching to it. This means the user's setting for "Activate last active tab on panel switching" won't be respected.

This commit creates consistency in these hotkeys.


## Switch to {next, previous} panel

```js
if (name === 'next_panel') Sidebar.switchPanel(1, false, true)
else if (name === 'prev_panel') Sidebar.switchPanel(-1, false, true)
```

Calls `Sidebar.switchPanel` which in turn should call `Sidebar.switchToPanel` which calls `Sidebar.activatePanel` and continues on to respect `Settings.state.activateLastTabOnPanelSwitching` and may call `Tabs.activateLastActiveTabOf`.


## Switch to {first, ..., tenth} panel

```js
} else if (name.startsWith('switch_to_panel_')) {
  const panel = Sidebar.panels[parseInt(name.slice(-1))]
  if (panel) Sidebar.switchToPanel(panel.id)
}
```

Likewise calls `Sidebar.switchToPanel` which calls `Sidebar.activatePanel` and continues on to respect `Settings.state.activateLastTabOnPanelSwitching` and may call `Tabs.activateLastActiveTabOf`.


## Switch to previously active panel

```js
} else if (name === 'switch_to_prev_panel') onKeySwitchToPrevPanel()

// [...]

function onKeySwitchToPrevPanel() {
  if (Sidebar.lastActivePanelId === Sidebar.activePanelId) return
  const prevPanel = Sidebar.panelsById[Sidebar.lastActivePanelId]
  if (!prevPanel) return

  Sidebar.activatePanel(Sidebar.lastActivePanelId)
}
```

Only calls `Sidebar.activatePanel` directly, and then never has the opportunity to follow `Settings.state.activateLastTabOnPanelSwitching`.

## Resolution

To create consistency across these hotkeys, update the call from `Sidebar.activatePanel` to `Sidebar.switchToPanel` for "Switch to previously active panel".