### PR TITLE
l10n: fr: fix the translation for 'Unload'

### DIFF
--- a/src/_locales/dict.common.ts
+++ b/src/_locales/dict.common.ts
@@ -1936,7 +1936,7 @@ export const commonTranslations: Translations = {
   'menu.tab.discard': {
     en: 'Unload',
     de: 'Entladen',
-    fr: 'Actualiser',
+    fr: 'Décharger',
     hu: 'Kisöprés',
     pl: 'Uśpij',
     ru: 'Выгрузить',


### PR DESCRIPTION
'Unload' was translated as 'Actualiser', but 'Actualiser' means 'Refresh' in English. 'Unload' can be translated as 'Décharger' in French.