### PR TITLE
Add duplicate tab functionality on long left click

### DIFF
--- a/src/services/mouse.fg.ts
+++ b/src/services/mouse.fg.ts
@@ -215,6 +215,7 @@ export function startLongClick(
       if (action === 'reload') Tabs.reloadTabs([tab.id])
       if (action === 'discard') Tabs.discardTabs([tab.id])
       if (action === 'duplicate') Tabs.duplicateTabs([tab.id])
+      if (action === 'dup_child') Tabs.duplicateTabs([tab.id], true)
       if (action === 'pin') Tabs.repinTabs([tab.id])
       if (action === 'mute') Tabs.remuteTabs([tab.id])
       if (action === 'clear_cookies') Tabs.clearTabsCookies([tab.id])

--- a/src/sidebar/components/tab.vue
+++ b/src/sidebar/components/tab.vue
@@ -268,11 +268,6 @@ function onMouseDown(e: MouseEvent): void {
       e.preventDefault()
       return
     }
-    
-    if (Settings.state.tabLongLeftClick === 'dup_child') {
-      Tabs.duplicateTabs([tab.id], true)
-      return
-    }
 
     if (Selection.isSet() && !(tab.sel || tab.selLock)) Selection.resetSelection()
 

--- a/src/sidebar/components/tab.vue
+++ b/src/sidebar/components/tab.vue
@@ -268,6 +268,11 @@ function onMouseDown(e: MouseEvent): void {
       e.preventDefault()
       return
     }
+    
+    if (Settings.state.tabLongLeftClick === 'dup_child') {
+      Tabs.duplicateTabs([tab.id], true)
+      return
+    }
 
     if (Selection.isSet() && !(tab.sel || tab.selLock)) Selection.resetSelection()
 


### PR DESCRIPTION
Quick scan of the code seems there's no handler for this option in the left click handler.

On 'dup_child':

https://github.com/search?q=repo%3Ambnuqw%2Fsidebery%20dup_child&type=code

On 'tabLongLeftClick'

https://github.com/search?q=repo%3Ambnuqw%2Fsidebery+tabLongLeftClick&type=code

#1604

Untested as I don't have node to build this locally so hopefully there's CI that I can build and test.