### PR TITLE
fix: middle click to unload tab panel respects the `pinnedNoUnload` setting

### DIFF
--- a/src/sidebar/components/bar.navigation.vue
+++ b/src/sidebar/components/bar.navigation.vue
@@ -517,7 +517,9 @@ async function onNavMouseDown(e: MouseEvent, item: T.NavItem) {
 
       // Discard(unload) tabs
       if (Settings.state.navTabsPanelMidClickAction === 'discard') {
-        const ids = panel.tabs.map(t => t.id)
+        const ids: ID[] = []
+        panel.pinnedTabs.forEach(t => ids.push(t.id))
+        panel.tabs.forEach(t => ids.push(t.id))
         if (ids.length) Tabs.discardTabs(ids)
       }
 


### PR DESCRIPTION
Unloading a tabs panel by middle clicking it on the navbar always ignores pinned tabs, regardless of the `Prevent pinned tabs from unloading` setting, as opposed to using the context menu action and the `Unload all tabs in inactive panels` keybinding.

reproduce/verify with:
- `Prevent pinned tabs from unloading`: `off`
- Navigation bar actions > `Middle click on tabs panel`: `unload tabs`
- have 1 loaded pinned tab in a panel and discard the panel using MMB or context menu