### PR TITLE
fix: keep "Prevent pinned tabs from unloading" setting enabled when pinned tabs are global

### DIFF
--- a/src/page.setup/components/settings.tabs.vue
+++ b/src/page.setup/components/settings.tabs.vue
@@ -297,7 +297,6 @@ section(ref="el")
       @update:value="Settings.saveDebounced(150)")
     ToggleField(
       label="settings.pinned.no_unload"
-      :inactive="Settings.state.pinnedTabsPosition !== 'panel'"
       dbg="pinnedNoUnload"
       v-model:value="Settings.state.pinnedNoUnload"
       :default="DEFAULT_SETTINGS.pinnedNoUnload"

--- a/src/services/menu.fg.options.tabs.ts
+++ b/src/services/menu.fg.options.tabs.ts
@@ -299,6 +299,7 @@ export const tabsMenuOptions: Record<string, () => MenuOption | MenuOption[] | u
     const option: MenuOption = {
       label: translate('menu.tab.discard'),
       icon: 'icon_discard',
+      inactive: Settings.state.pinnedNoUnload,
       onClick: () => Tabs.discardTabs(Selection.ids()),
     }
     const firstTab = Tabs.byId[Selection.getFirst()]
@@ -773,6 +774,7 @@ export const tabsMenuOptions: Record<string, () => MenuOption | MenuOption[] | u
     const option: MenuOption = {
       label: translate('menu.tabs_panel.discard'),
       icon: 'icon_discard',
+      inactive: Settings.state.pinnedNoUnload && !panel.tabs.length,
       onClick: () => Tabs.discardTabs(tabIds),
     }
     if (!tabIds.length) option.inactive = true


### PR DESCRIPTION
Resolves #2309

also please see: https://github.com/mbnuqw/sidebery/issues/2309#issuecomment-3801133145

> Right clicking a specific pinned tab to unload it should bypass the setting maybe?
> And if not, then the unload option should be hidden in the context menu depending on the prevent unload setting's value.