### PR TITLE
issue-2359: fix drag and drop one pixel before slot start case

### DIFF
--- a/src/services/drag-and-drop.fg.ts
+++ b/src/services/drag-and-drop.fg.ts
@@ -915,7 +915,7 @@ export function onDragMove(e: DragEvent): void {
     if (y > slot.end) path[slot.lvl] = slot
 
     // Skip
-    if (!lvlChanged && (y > slot.end || y < slot.start)) continue
+    if (!lvlChanged && (y > slot.end || y < slot.start - 1)) continue
 
     // Between
     if (slot.in ? y < slot.top : y < slot.center) {
@@ -972,7 +972,9 @@ export function onDragMove(e: DragEvent): void {
           DnD.reactive.dstParentId = parentSlot?.id ?? D.NOID
         }
       }
-      break
+      if (y !== slot.start - 1) {
+        break
+      }
     }
 
     // Inside


### PR DESCRIPTION
Fixes https://github.com/mbnuqw/sidebery/issues/2359

If group you're dragging a tab onto is at index 3 and then in `drag-and-drop.fg.ts#onDragMove`

```
  y = bounds[3].start - 1
```
DnD.reactive.dstParentId isn't set, so remains -1, so DnD results in tab being moved to bottom/top of panel depending on config.

Changes allows execution to make it to `// Inside` section when this happens. It handles as expected then.

I'm not sure if there's a more elegant fix or if this covers all cases, but this seems to fix this one particular case. If you can find a superset of cases feel free to discard for a better fix.