### PR TITLE
feat: add 'Unload other tabs' tab menu option

### DIFF
--- a/src/_locales/dict.common.ts
+++ b/src/_locales/dict.common.ts
@@ -1955,6 +1955,17 @@ export const commonTranslations: Translations = {
     zh_TW: '卸載分頁',
     ja: 'アンロード',
   },
+  'menu.tab.discard_other': {
+    en: 'Unload other tabs',
+    de: 'Andere Tabs entladen',
+    fr: 'Décharger les autres onglets',
+    hu: 'A többi lap kisöprése',
+    pl: 'Uśpij inne karty',
+    ru: 'Выгрузить другие вкладки',
+    zh_CN: '卸载其他标签页',
+    zh_TW: '卸載其他分頁',
+    ja: '他のタブをアンロード',
+  },
   'menu.tab.edit_title': {
     en: 'Edit title',
     de: 'Titel bearbeiten',

--- a/src/defaults/mocks.tabs.fg.ts
+++ b/src/defaults/mocks.tabs.fg.ts
@@ -64,7 +64,6 @@ export class MTab implements Tab {
     branchColor: null,
     customColor: null,
     isGroup: false,
-    preview: false,
   }
   sessionData?: TabSessionData | undefined
   titleEl?: HTMLElement | undefined

--- a/src/page.setup/components/menu-editor.vue
+++ b/src/page.setup/components/menu-editor.vue
@@ -174,6 +174,7 @@ const TABS_MENU_OPTS: Record<string, string> = {
   mute: 'menu.tab.mute',
   duplicate: 'menu.tab.duplicate',
   discard: 'menu.tab.discard',
+  discardOtherTabs: 'menu.tab.discard_other',
   dedupeTabs: 'menu.dedupe',
   copyTabsUrls: 'menu.copy_urls',
   copyTabsTitles: 'menu.copy_titles',

--- a/src/services/menu.fg.options.tabs.ts
+++ b/src/services/menu.fg.options.tabs.ts
@@ -309,6 +309,33 @@ export const tabsMenuOptions: Record<string, () => MenuOption | MenuOption[] | u
     return option
   },
 
+  discardOtherTabs: () => {
+    const option: MenuOption = {
+      label: translate('menu.tab.discard_other'),
+      icon: 'icon_discard',
+      onClick: () => {
+        const ids = Selection.ids()
+        const firstTab = Tabs.byId[ids[0]]
+        if (!firstTab) return
+        const panel = Sidebar.panelsById[firstTab.panelId]
+        if (!Utils.isTabsPanel(panel)) return
+        const tabIds: ID[] = []
+        panel.tabs.forEach(t => !ids.includes(t.id) && tabIds.push(t.id))
+        if (tabIds.length) Tabs.discardTabs(tabIds)
+      },
+    }
+
+    const tabId = Selection.getFirst()
+    const tab = Tabs.byId[tabId]
+    if (!tab || tab.pinned) option.inactive = true
+    if (tab) {
+      const panel = Sidebar.panelsById[tab.panelId]
+      if (!panel || panel.reactive.len === 1) option.inactive = true
+    }
+    if (!Settings.state.ctxMenuRenderInact && option.inactive) return
+    return option
+  },
+
   group: () => {
     const option: MenuOption = {
       label: translate('menu.tab.group'),

--- a/src/services/menu.fg.options.tabs.ts
+++ b/src/services/menu.fg.options.tabs.ts
@@ -310,27 +310,37 @@ export const tabsMenuOptions: Record<string, () => MenuOption | MenuOption[] | u
   },
 
   discardOtherTabs: () => {
+    const getEligibleTabIds = (): ID[] => {
+      const tabIds: ID[] = []
+      const ids = Selection.ids()
+      const firstTab = Tabs.byId[ids[0]]
+      if (firstTab) {
+        const panel = Sidebar.panelsById[firstTab.panelId]
+        if (Utils.isTabsPanel(panel)) {
+          panel.tabs.forEach(t => !ids.includes(t.id) && tabIds.push(t.id))
+          if (!Settings.state.pinnedNoUnload || !Settings.state.pinnedNoUnloadExplicit) {
+            panel.pinnedTabs.forEach(t => !ids.includes(t.id) && tabIds.push(t.id))
+          }
+        }
+      }
+      return tabIds
+    }
+
     const option: MenuOption = {
       label: translate('menu.tab.discard_other'),
       icon: 'icon_discard',
       onClick: () => {
-        const ids = Selection.ids()
-        const firstTab = Tabs.byId[ids[0]]
-        if (!firstTab) return
-        const panel = Sidebar.panelsById[firstTab.panelId]
-        if (!Utils.isTabsPanel(panel)) return
-        const tabIds: ID[] = []
-        panel.tabs.forEach(t => !ids.includes(t.id) && tabIds.push(t.id))
-        if (tabIds.length) Tabs.discardTabs(tabIds)
+        const tabIds: ID[] = getEligibleTabIds()
+        if (tabIds.length) Tabs.discardTabs(tabIds, true)
       },
     }
 
     const tabId = Selection.getFirst()
     const tab = Tabs.byId[tabId]
-    if (!tab || tab.pinned) option.inactive = true
-    if (tab) {
+    if (!tab) option.inactive = true
+    else {
       const panel = Sidebar.panelsById[tab.panelId]
-      if (!panel || panel.reactive.len === 1) option.inactive = true
+      if (!panel || getEligibleTabIds().length === 0) option.inactive = true
     }
     if (!Settings.state.ctxMenuRenderInact && option.inactive) return
     return option


### PR DESCRIPTION
Closes https://github.com/mbnuqw/sidebery/issues/2129

- Adds an `Unload other tabs` tab menu option. 
- Only unloads other tabs in panel, going off `Close other tabs` precedent.
- Added translations. 
- Checks `Prevent pinned tabs from unloading` > `Including explicit unloading via context menu, mouse action or keybinding` setting to decide whether to unload pinned tabs.
- Doesn't add to default menu options.
- Inactive if no eligible tabs to unload.

<img width="1605" height="341" alt="image" src="https://github.com/user-attachments/assets/6cfaf28a-8711-4a12-b6d3-2d53bb465616" />

Demo video:

https://github.com/user-attachments/assets/c5ad869d-1eaf-43a4-a4a2-ff6d31e08c22

