### PR TITLE
Quality: Duplicate HTML id attribute in search.html

### DIFF
--- a/src/popup.search/search.html
+++ b/src/popup.search/search.html
@@ -52,7 +52,7 @@
     style="background-color: -moz-dialog; color: -moz-dialogtext; position: absolute; width: 0; height: 0;">
   </div>
   <inject>svg://src/assets/search.svg#icon_search</inject>
-  <input id="textInput" type="text" id="hm">
+  <input id="textInput" type="text">
   <script type="module" src="./search.js" defer></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary

Quality: Duplicate HTML id attribute in search.html

## Problem

**Severity**: `High` | **File**: `src/popup.search/search.html:L38`

The input element has two `id` attributes: `id="textInput"` and `id="hm"`. HTML elements can only have one id attribute, and having duplicate ids can cause unpredictable behavior in JavaScript DOM operations and CSS selectors.

## Solution

Remove the duplicate `id="hm"` attribute or merge them into a single id if both are needed for different purposes.

## Changes

- `src/popup.search/search.html` (modified)