### PR TITLE
feat: read/write API for panels and tab trees

### DIFF
--- a/docs/wiki/External-API.md
+++ b/docs/wiki/External-API.md
@@ -1,0 +1,73 @@
+# External API
+
+Sidebery exposes a versioned WebExtension API for integrations that need its panel and tab-tree model. Requests use Firefox's `runtime.sendMessage(extensionId, message)` API and must include the Firefox window whose Sidebery sidebar should handle the request.
+
+Sidebery's published extension ID is `{3c078156-979c-498b-8990-85f7987dd929}`.
+
+```js
+const { id: windowId } = await browser.windows.getCurrent()
+const response = await browser.runtime.sendMessage('{3c078156-979c-498b-8990-85f7987dd929}', {
+  type: 'sidebery-api',
+  version: 1,
+  method: 'get-state',
+  windowId,
+})
+
+if (!response.ok) throw new Error(`${response.error.code}: ${response.error.message}`)
+```
+
+The API deliberately returns structural state only. Use Firefox's `tabs` API for native tab properties such as URL and title, joining records by tab ID.
+
+## Methods
+
+### `get-state`
+
+Returns the active panel, all panels, and every tab's panel and tree position. Tab records include `parentId`, `ancestorIds`, `childIds`, `level`, `folded`, and group flags.
+
+### `move-tabs`
+
+Moves tabs and their descendants. `params.tabIds` is required. The destination may include `panelId`, `parentId`, `beforeTabId`, or `afterTabId`. Set `parentId` to `null` to place tabs at the tree root.
+
+```js
+params: { tabIds: [12], panelId: 'work', parentId: 8 }
+```
+
+### `create-group`
+
+Creates a Sidebery group around tabs in one panel.
+
+```js
+params: { tabIds: [12, 15], title: 'Research' }
+```
+
+### `remove-group`
+
+Removes a group tab while preserving its descendants, promoting them to the group's parent.
+
+```js
+params: {
+  groupTabId: 18
+}
+```
+
+### `rename-group`
+
+Renames a group tab.
+
+```js
+params: { groupTabId: 18, title: 'References' }
+```
+
+### `flatten-tabs`
+
+Removes tabs from their current parent while preserving their order.
+
+```js
+params: {
+  tabIds: [12, 15]
+}
+```
+
+## Responses
+
+Every response includes `type: "sidebery-api"`, `version: 1`, and either `{ ok: true, result }` or `{ ok: false, error: { code, message } }`. Callers should treat unknown fields as forward-compatible additions and reject API versions they do not understand.

--- a/src/bg/background.ts
+++ b/src/bg/background.ts
@@ -18,6 +18,7 @@ import * as WebReq from 'src/services/web-req.bg'
 import * as Sync from 'src/services/sync.bg'
 import * as Omnibox from 'src/services/omnibox.bg'
 import * as Styles from 'src/services/styles.bg'
+import * as ExternalApi from 'src/services/external-api.bg'
 
 void (async function main() {
   markLocalStorage()
@@ -73,6 +74,7 @@ void (async function main() {
   // Init first-need stuff
   IPC.setupGlobalMessageListener()
   IPC.setupConnectionListener()
+  ExternalApi.setupListener()
   await Promise.all([Windows.load(), Containers.load(), Settings.load(), Info.loadVersionInfo()])
 
   Info.saveVersion()

--- a/src/services/external-api.bg.test.ts
+++ b/src/services/external-api.bg.test.ts
@@ -1,0 +1,64 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+import { InstanceType } from 'src/enums'
+import { EXTERNAL_API_MESSAGE_TYPE, EXTERNAL_API_VERSION } from 'src/types'
+import * as IPC from 'src/services/ipc'
+import { handleMessage } from 'src/services/external-api.bg'
+
+const request = {
+  type: EXTERNAL_API_MESSAGE_TYPE,
+  version: EXTERNAL_API_VERSION,
+  method: 'get-state' as const,
+  windowId: 12,
+}
+const sender = { id: 'consumer@example.com' }
+
+describe('ExternalApi.handleMessage()', () => {
+  beforeEach(() => {
+    vi.mocked(IPC.isConnected).mockReturnValue(true)
+    vi.mocked(IPC.sidebar).mockResolvedValue({
+      result: { windowId: 12, panels: [], tabs: [] },
+    })
+  })
+
+  test('ignores messages for other APIs', async () => {
+    expect(await handleMessage({ type: 'other' }, sender)).toBeUndefined()
+    expect(IPC.sidebar).not.toHaveBeenCalled()
+  })
+
+  test('rejects unsupported versions', async () => {
+    const response = await handleMessage({ ...request, version: 2 }, sender)
+    expect(response).toMatchObject({ ok: false, error: { code: 'UNSUPPORTED_VERSION' } })
+  })
+
+  test('reports unavailable sidebar windows', async () => {
+    vi.mocked(IPC.isConnected).mockReturnValue(false)
+    const response = await handleMessage(request, sender)
+    expect(response).toMatchObject({ ok: false, error: { code: 'SIDEBAR_UNAVAILABLE' } })
+    expect(IPC.isConnected).toHaveBeenCalledWith(InstanceType.sidebar, 12)
+  })
+
+  test('routes valid requests to the matching sidebar', async () => {
+    const response = await handleMessage(request, sender)
+    expect(IPC.sidebar).toHaveBeenCalledWith(12, 'externalApiRequest', request)
+    expect(response).toEqual({
+      type: EXTERNAL_API_MESSAGE_TYPE,
+      version: EXTERNAL_API_VERSION,
+      ok: true,
+      result: { windowId: 12, panels: [], tabs: [] },
+    })
+  })
+
+  test('preserves errors returned by the sidebar handler', async () => {
+    vi.mocked(IPC.sidebar).mockResolvedValue({
+      error: { code: 'PANEL_NOT_FOUND', message: 'Cannot find tabs panel missing' },
+    })
+
+    const response = await handleMessage(request, sender)
+    expect(response).toEqual({
+      type: EXTERNAL_API_MESSAGE_TYPE,
+      version: EXTERNAL_API_VERSION,
+      ok: false,
+      error: { code: 'PANEL_NOT_FOUND', message: 'Cannot find tabs panel missing' },
+    })
+  })
+})

--- a/src/services/external-api.bg.ts
+++ b/src/services/external-api.bg.ts
@@ -1,0 +1,55 @@
+import type * as T from 'src/types'
+import { EXTERNAL_API_MESSAGE_TYPE, EXTERNAL_API_VERSION } from 'src/types'
+import { InstanceType } from 'src/enums'
+import * as IPC from 'src/services/ipc'
+
+function error(code: string, message: string): T.ExternalApiResponse {
+  return {
+    type: EXTERNAL_API_MESSAGE_TYPE,
+    version: EXTERNAL_API_VERSION,
+    ok: false,
+    error: { code, message },
+  }
+}
+
+function isExternalApiRequest(value: unknown): value is T.ExternalApiRequest {
+  if (!value || typeof value !== 'object') return false
+  return (value as { type?: unknown }).type === EXTERNAL_API_MESSAGE_TYPE
+}
+
+export async function handleMessage(
+  message: unknown,
+  sender: browser.runtime.Sender
+): Promise<T.ExternalApiResponse | undefined> {
+  if (!isExternalApiRequest(message)) return
+  if (!sender.id) return error('INVALID_SENDER', 'The request must come from another extension')
+  if (message.version !== EXTERNAL_API_VERSION) {
+    return error(
+      'UNSUPPORTED_VERSION',
+      `Unsupported API version ${String(message.version)}; expected ${EXTERNAL_API_VERSION}`
+    )
+  }
+  if (!Number.isInteger(message.windowId)) {
+    return error('INVALID_WINDOW', 'windowId must be an integer')
+  }
+  if (!IPC.isConnected(InstanceType.sidebar, message.windowId)) {
+    return error('SIDEBAR_UNAVAILABLE', `Sidebery is not connected to window ${message.windowId}`)
+  }
+
+  try {
+    const response = await IPC.sidebar(message.windowId, 'externalApiRequest', message)
+    if (response.error) return error(response.error.code, response.error.message)
+    return {
+      type: EXTERNAL_API_MESSAGE_TYPE,
+      version: EXTERNAL_API_VERSION,
+      ok: true,
+      result: response.result,
+    }
+  } catch (err) {
+    return error('REQUEST_FAILED', String(err))
+  }
+}
+
+export function setupListener(): void {
+  browser.runtime.onMessageExternal.addListener(handleMessage)
+}

--- a/src/services/external-api.fg.test.ts
+++ b/src/services/external-api.fg.test.ts
@@ -1,0 +1,133 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { PanelType } from 'src/enums'
+import { EXTERNAL_API_MESSAGE_TYPE, EXTERNAL_API_VERSION } from 'src/types'
+import { addMPanel, resetMSidebar } from 'src/defaults/mocks.sidebar.fg'
+import { addMTTab, resetMTabs } from 'src/defaults/mocks.tabs.fg'
+import * as Sidebar from 'src/services/sidebar.fg'
+import * as Tabs from 'src/services/tabs.fg'
+import * as Windows from 'src/services/windows.fg'
+import { handleRequest } from 'src/services/external-api.fg'
+
+describe('ExternalApi.handleRequest()', () => {
+  beforeEach(() => {
+    vi.spyOn(Tabs, 'waitForTabsReady').mockResolvedValue()
+    Windows.setCurrentId(12)
+    addMPanel({ id: 'work', type: PanelType.tabs, name: 'Work', nextTabIndex: 2 })
+    addMPanel({ id: 'research', type: PanelType.tabs, name: 'Research', nextTabIndex: 10 })
+    Sidebar.setActivePanelId('work')
+    addMTTab({ id: 1, panelId: 'work' })
+    addMTTab(1, { id: 2, panelId: 'work' })
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    resetMTabs()
+    resetMSidebar()
+  })
+
+  test('returns panel and hierarchy state without native tab metadata', async () => {
+    const state = await handleRequest({
+      type: EXTERNAL_API_MESSAGE_TYPE,
+      version: EXTERNAL_API_VERSION,
+      method: 'get-state',
+      windowId: 12,
+    })
+
+    expect(state).toMatchObject({
+      windowId: 12,
+      activePanelId: 'work',
+      panels: [
+        { id: 'work', type: 'tabs', name: 'Work' },
+        { id: 'research', type: 'tabs', name: 'Research' },
+      ],
+      tabs: [
+        { id: 1, panelId: 'work', parentId: null, childIds: [2], ancestorIds: [] },
+        { id: 2, panelId: 'work', parentId: 1, childIds: [], ancestorIds: [1] },
+      ],
+    })
+  })
+
+  test('moves complete branches between panels through Sidebery', async () => {
+    const move = vi.spyOn(Tabs, 'move').mockResolvedValue()
+    await handleRequest({
+      type: EXTERNAL_API_MESSAGE_TYPE,
+      version: EXTERNAL_API_VERSION,
+      method: 'move-tabs',
+      windowId: 12,
+      params: { tabIds: [1], panelId: 'research', parentId: null },
+    })
+
+    expect(move).toHaveBeenCalledWith(
+      [expect.objectContaining({ id: 1 }), expect.objectContaining({ id: 2 })],
+      { windowId: 12, panelId: 'work', pinned: false },
+      { windowId: 12, panelId: 'research', parentId: -1, index: 10 }
+    )
+  })
+
+  test('rejects an anchor outside the requested parent', async () => {
+    addMTTab(1, { id: 3, panelId: 'work' })
+    await expect(
+      handleRequest({
+        type: EXTERNAL_API_MESSAGE_TYPE,
+        version: EXTERNAL_API_VERSION,
+        method: 'move-tabs',
+        windowId: 12,
+        params: { tabIds: [2], parentId: null, beforeTabId: 3 },
+      })
+    ).rejects.toMatchObject({ code: 'INVALID_DESTINATION' })
+  })
+
+  test('renames groups through the existing group service', async () => {
+    const groupTab = Tabs.byId[1]
+    if (!groupTab) throw new Error('Missing test group')
+    groupTab.isGroup = true
+    const setGroupName = vi.spyOn(Tabs, 'setGroupName').mockResolvedValue()
+
+    await handleRequest({
+      type: EXTERNAL_API_MESSAGE_TYPE,
+      version: EXTERNAL_API_VERSION,
+      method: 'rename-group',
+      windowId: 12,
+      params: { groupTabId: 1, title: 'References' },
+    })
+
+    expect(setGroupName).toHaveBeenCalledWith(1, 'References')
+  })
+
+  test('flattens hierarchy through the existing tree service', async () => {
+    const flattenTabs = vi.spyOn(Tabs, 'flattenTabs').mockReturnValue()
+
+    await handleRequest({
+      type: EXTERNAL_API_MESSAGE_TYPE,
+      version: EXTERNAL_API_VERSION,
+      method: 'flatten-tabs',
+      windowId: 12,
+      params: { tabIds: [2] },
+    })
+
+    expect(flattenTabs).toHaveBeenCalledWith([2])
+  })
+
+  test('removes a group while promoting its descendants', async () => {
+    const groupTab = Tabs.byId[1]
+    if (!groupTab) throw new Error('Missing test group')
+    groupTab.isGroup = true
+    const move = vi.spyOn(Tabs, 'move').mockResolvedValue()
+    const removeTabs = vi.spyOn(Tabs, 'removeTabs').mockResolvedValue()
+
+    await handleRequest({
+      type: EXTERNAL_API_MESSAGE_TYPE,
+      version: EXTERNAL_API_VERSION,
+      method: 'remove-group',
+      windowId: 12,
+      params: { groupTabId: 1 },
+    })
+
+    expect(move).toHaveBeenCalledWith(
+      [expect.objectContaining({ id: 2 })],
+      { windowId: 12, panelId: 'work' },
+      { windowId: 12, panelId: 'work', parentId: -1, index: 1 }
+    )
+    expect(removeTabs).toHaveBeenCalledWith([1], true)
+  })
+})

--- a/src/services/external-api.fg.ts
+++ b/src/services/external-api.fg.ts
@@ -1,0 +1,320 @@
+import type * as T from 'src/types'
+import { ExternalApiRequestError } from 'src/types'
+import { PanelType } from 'src/enums'
+import { NOID } from 'src/defaults'
+import * as Utils from 'src/utils'
+import * as Sidebar from 'src/services/sidebar.fg'
+import * as Tabs from 'src/services/tabs.fg'
+import * as Windows from 'src/services/windows.fg'
+
+function fail(code: string, message: string): never {
+  throw new ExternalApiRequestError(code, message)
+}
+
+function isId(value: unknown): value is ID {
+  return typeof value === 'number' || typeof value === 'string'
+}
+
+function getObjectParams(request: T.ExternalApiRequest): Record<string, unknown> {
+  if (!request.params || typeof request.params !== 'object' || Array.isArray(request.params)) {
+    return fail('INVALID_PARAMS', `Method "${request.method}" requires object params`)
+  }
+  return request.params as Record<string, unknown>
+}
+
+function getTabIds(value: unknown): ID[] {
+  if (!Array.isArray(value) || !value.length || !value.every(isId)) {
+    return fail('INVALID_PARAMS', 'tabIds must be a non-empty array of tab IDs')
+  }
+
+  const tabIds = [...new Set(value)]
+  for (const tabId of tabIds) {
+    if (!Tabs.byId[tabId]) fail('TAB_NOT_FOUND', `Cannot find tab ${String(tabId)}`)
+  }
+  return tabIds
+}
+
+function getTitle(value: unknown): string {
+  if (typeof value !== 'string' || !value.trim()) {
+    return fail('INVALID_PARAMS', 'title must be a non-empty string')
+  }
+  return value.trim().slice(0, 256)
+}
+
+function getPanelType(panel: T.Panel): T.ExternalApiPanelType {
+  if (panel.type === PanelType.tabs) return 'tabs'
+  if (panel.type === PanelType.bookmarks) return 'bookmarks'
+  if (panel.type === PanelType.history) return 'history'
+  return 'sync'
+}
+
+function serializePanels(): T.ExternalApiPanel[] {
+  return Sidebar.panels.map(panel => ({
+    id: panel.id,
+    index: panel.index,
+    type: getPanelType(panel),
+    name: panel.name,
+    color: panel.color,
+  }))
+}
+
+function serializeTabs(tabIds?: Set<ID>): T.ExternalApiTab[] {
+  const childIds = new Map<ID, ID[]>()
+  for (const tab of Tabs.list) {
+    if (tab.parentId === NOID) continue
+    const children = childIds.get(tab.parentId)
+    if (children) children.push(tab.id)
+    else childIds.set(tab.parentId, [tab.id])
+  }
+
+  const result: T.ExternalApiTab[] = []
+  for (const tab of Tabs.list) {
+    if (tabIds && !tabIds.has(tab.id)) continue
+
+    const ancestorIds: ID[] = []
+    const visited = new Set<ID>()
+    let parent = Tabs.byId[tab.parentId]
+    while (parent && !visited.has(parent.id)) {
+      ancestorIds.unshift(parent.id)
+      visited.add(parent.id)
+      parent = Tabs.byId[parent.parentId]
+    }
+
+    result.push({
+      id: tab.id,
+      index: tab.index,
+      panelId: tab.panelId,
+      parentId: tab.parentId === NOID ? null : tab.parentId,
+      ancestorIds,
+      childIds: childIds.get(tab.id) ?? [],
+      level: tab.lvl,
+      pinned: tab.pinned,
+      folded: tab.folded,
+      isParent: tab.isParent,
+      isGroup: tab.isGroup,
+    })
+  }
+  return result
+}
+
+function getState(): T.ExternalApiState {
+  return {
+    windowId: Windows.id,
+    activePanelId: Sidebar.activePanelId,
+    panels: serializePanels(),
+    tabs: serializeTabs(),
+  }
+}
+
+function getMovingTabs(tabIds: ID[]): T.Tab[] {
+  const selected = new Set(tabIds)
+  const roots = tabIds
+    .map(id => Tabs.byId[id])
+    .filter((tab): tab is T.Tab => {
+      if (!tab) return false
+      let parent = Tabs.byId[tab.parentId]
+      while (parent) {
+        if (selected.has(parent.id)) return false
+        parent = Tabs.byId[parent.parentId]
+      }
+      return true
+    })
+    .sort((a, b) => a.index - b.index)
+
+  const movingTabs: T.Tab[] = []
+  const added = new Set<ID>()
+  for (const root of roots) {
+    for (const tab of Tabs.getBranch(root)) {
+      if (added.has(tab.id)) continue
+      movingTabs.push(tab)
+      added.add(tab.id)
+    }
+  }
+  return movingTabs
+}
+
+function getDestination(params: T.ExternalApiMoveTabsParams, movingTabs: T.Tab[]): T.DstPlaceInfo {
+  const firstMovingTab = movingTabs[0]
+  if (!firstMovingTab) return fail('INVALID_PARAMS', 'No tabs to move')
+
+  if (params.beforeTabId !== undefined && params.afterTabId !== undefined) {
+    return fail('INVALID_PARAMS', 'Use either beforeTabId or afterTabId, not both')
+  }
+
+  const anchorId = params.beforeTabId ?? params.afterTabId
+  const anchor = anchorId === undefined ? undefined : Tabs.byId[anchorId]
+  if (anchorId !== undefined && !anchor) {
+    return fail('TAB_NOT_FOUND', `Cannot find anchor tab ${String(anchorId)}`)
+  }
+
+  const requestedParentId = params.parentId === null ? NOID : params.parentId
+  const parent = requestedParentId === undefined ? undefined : Tabs.byId[requestedParentId]
+  if (requestedParentId !== undefined && requestedParentId !== NOID && !parent) {
+    return fail('TAB_NOT_FOUND', `Cannot find parent tab ${String(requestedParentId)}`)
+  }
+
+  const movingIds = new Set(movingTabs.map(tab => tab.id))
+  if (parent && movingIds.has(parent.id)) {
+    return fail('INVALID_DESTINATION', 'A tab cannot be moved below itself or its descendant')
+  }
+  if (anchor && movingIds.has(anchor.id)) {
+    return fail('INVALID_DESTINATION', 'The destination anchor cannot be one of the moved tabs')
+  }
+
+  let panelId = params.panelId
+  if (panelId === undefined) panelId = parent?.panelId ?? anchor?.panelId ?? firstMovingTab.panelId
+
+  const panel = Sidebar.panelsById[panelId]
+  if (!Utils.isTabsPanel(panel)) {
+    return fail('PANEL_NOT_FOUND', `Cannot find tabs panel ${String(panelId)}`)
+  }
+  if (parent && parent.panelId !== panelId) {
+    return fail('INVALID_DESTINATION', 'The destination parent belongs to another panel')
+  }
+  if (anchor && anchor.panelId !== panelId) {
+    return fail('INVALID_DESTINATION', 'The destination anchor belongs to another panel')
+  }
+  if (anchor && requestedParentId !== undefined && anchor.parentId !== requestedParentId) {
+    return fail('INVALID_DESTINATION', 'The destination anchor belongs to another parent')
+  }
+
+  let parentId = requestedParentId
+  if (parentId === undefined) {
+    if (anchor) parentId = anchor.parentId
+    else if (panelId === firstMovingTab.panelId) parentId = firstMovingTab.parentId
+    else parentId = NOID
+  }
+  if (parentId !== NOID && movingTabs.some(tab => tab.pinned)) {
+    return fail('INVALID_DESTINATION', 'Pinned tabs cannot be placed in a tab tree')
+  }
+
+  let index: number
+  if (params.beforeTabId !== undefined && anchor) {
+    index = anchor.index
+  } else if (params.afterTabId !== undefined && anchor) {
+    index = anchor.index + (Tabs.getBranchLen(anchor.id) ?? 0) + 1
+  } else if (parent) {
+    index = parent.index + (Tabs.getBranchLen(parent.id) ?? 0) + 1
+  } else {
+    index = panel.nextTabIndex
+  }
+
+  return { windowId: Windows.id, panelId, parentId, index }
+}
+
+async function moveTabs(request: T.ExternalApiRequest): Promise<T.ExternalApiMutationResult> {
+  const params = getObjectParams(request) as unknown as T.ExternalApiMoveTabsParams
+  const tabIds = getTabIds(params.tabIds)
+  const movingTabs = getMovingTabs(tabIds)
+  const firstMovingTab = movingTabs[0]
+  if (!firstMovingTab) return fail('INVALID_PARAMS', 'No tabs to move')
+  const destination = getDestination(params, movingTabs)
+  const source: T.SrcPlaceInfo = {
+    windowId: Windows.id,
+    panelId: firstMovingTab.panelId,
+    pinned: firstMovingTab.pinned,
+  }
+
+  await Utils.GLOBAL_QUEUE.add(Tabs.move, movingTabs, source, destination)
+  return { tabs: serializeTabs(new Set(movingTabs.map(tab => tab.id))) }
+}
+
+async function createGroup(request: T.ExternalApiRequest): Promise<T.ExternalApiMutationResult> {
+  const params = getObjectParams(request) as unknown as T.ExternalApiCreateGroupParams
+  const tabIds = getTabIds(params.tabIds)
+  const title = getTitle(params.title)
+  const firstTabId = tabIds[0]
+  const firstTab = firstTabId === undefined ? undefined : Tabs.byId[firstTabId]
+  if (!firstTab) return fail('TAB_NOT_FOUND', 'Cannot find the first grouped tab')
+  if (tabIds.some(id => Tabs.byId[id]?.panelId !== firstTab.panelId)) {
+    return fail('INVALID_PARAMS', 'All grouped tabs must belong to the same panel')
+  }
+  if (tabIds.some(id => Tabs.byId[id]?.pinned)) {
+    return fail('INVALID_PARAMS', 'Pinned tabs cannot be placed in a group')
+  }
+
+  await Utils.GLOBAL_QUEUE.add(Tabs.groupTabs, tabIds, { title, active: false })
+  const groupTab = Tabs.byId[firstTab.parentId]
+  if (!groupTab?.isGroup) return fail('GROUP_CREATE_FAILED', 'Sidebery did not create a group')
+
+  const branchIds = new Set(Tabs.getBranch(groupTab).map(tab => tab.id))
+  return { groupTabId: groupTab.id, tabs: serializeTabs(branchIds) }
+}
+
+async function removeGroupAndKeepTabs(groupTabId: ID): Promise<ID[]> {
+  const groupTab = Tabs.byId[groupTabId]
+  if (!groupTab?.isGroup) return fail('GROUP_NOT_FOUND', `Cannot find group ${String(groupTabId)}`)
+
+  const children = Tabs.getBranch(groupTab, false)
+  if (children.length) {
+    await Tabs.move(
+      children,
+      { windowId: Windows.id, panelId: groupTab.panelId },
+      {
+        windowId: Windows.id,
+        panelId: groupTab.panelId,
+        parentId: groupTab.parentId,
+        index: groupTab.index + 1,
+      }
+    )
+  }
+  await Tabs.removeTabs([groupTabId], true)
+  return children.map(tab => tab.id)
+}
+
+async function removeGroup(request: T.ExternalApiRequest): Promise<T.ExternalApiMutationResult> {
+  const params = getObjectParams(request) as unknown as T.ExternalApiRemoveGroupParams
+  if (!isId(params.groupTabId)) return fail('INVALID_PARAMS', 'groupTabId must be a tab ID')
+
+  const childIds = await Utils.GLOBAL_QUEUE.add(removeGroupAndKeepTabs, params.groupTabId)
+  return {
+    removedGroupTabId: params.groupTabId,
+    tabs: serializeTabs(new Set(childIds)),
+  }
+}
+
+async function renameGroup(request: T.ExternalApiRequest): Promise<T.ExternalApiMutationResult> {
+  const params = getObjectParams(request) as unknown as T.ExternalApiRenameGroupParams
+  if (!isId(params.groupTabId)) return fail('INVALID_PARAMS', 'groupTabId must be a tab ID')
+  const groupTab = Tabs.byId[params.groupTabId]
+  if (!groupTab?.isGroup) {
+    return fail('GROUP_NOT_FOUND', `Cannot find group ${String(params.groupTabId)}`)
+  }
+
+  await Utils.GLOBAL_QUEUE.add(Tabs.setGroupName, groupTab.id, getTitle(params.title))
+  return { groupTabId: groupTab.id, tabs: serializeTabs(new Set([groupTab.id])) }
+}
+
+async function flattenTabs(request: T.ExternalApiRequest): Promise<T.ExternalApiMutationResult> {
+  const params = getObjectParams(request) as unknown as T.ExternalApiFlattenTabsParams
+  const tabIds = getTabIds(params.tabIds)
+  await Utils.GLOBAL_QUEUE.add(async () => Tabs.flattenTabs([...tabIds]))
+  return { tabs: serializeTabs(new Set(tabIds)) }
+}
+
+export async function handleRequest(request: T.ExternalApiRequest): Promise<unknown> {
+  await Tabs.waitForTabsReady()
+
+  if (request.method === 'get-state') return getState()
+  if (request.method === 'move-tabs') return moveTabs(request)
+  if (request.method === 'create-group') return createGroup(request)
+  if (request.method === 'remove-group') return removeGroup(request)
+  if (request.method === 'rename-group') return renameGroup(request)
+  if (request.method === 'flatten-tabs') return flattenTabs(request)
+
+  return fail('UNKNOWN_METHOD', `Unknown external API method: ${String(request.method)}`)
+}
+
+export async function handleIpcRequest(request: T.ExternalApiRequest): Promise<{
+  result?: unknown
+  error?: T.ExternalApiError
+}> {
+  try {
+    return { result: await handleRequest(request) }
+  } catch (err) {
+    if (err instanceof ExternalApiRequestError) {
+      return { error: { code: err.code, message: err.message } }
+    }
+    return { error: { code: 'REQUEST_FAILED', message: String(err) } }
+  }
+}

--- a/src/sidebar/sidebar.ts
+++ b/src/sidebar/sidebar.ts
@@ -26,6 +26,7 @@ import * as Snapshots from 'src/services/snapshots.fg'
 import * as Sync from 'src/services/sync.fg'
 import * as Keybindings from 'src/services/keybindings.fg'
 import * as WebReq from 'src/services/web-req.fg'
+import * as ExternalApi from 'src/services/external-api.fg'
 import SidebarRoot from './sidebar.vue'
 
 async function main(): Promise<void> {
@@ -38,6 +39,7 @@ async function main(): Promise<void> {
   Logs.info('Init start')
 
   IPC.registerActions({
+    externalApiRequest: ExternalApi.handleIpcRequest,
     reloadTab: Tabs.reloadTab,
     queryTab: Tabs.queryTab,
     getTabs: Tabs.getTabs,

--- a/src/types.ts
+++ b/src/types.ts
@@ -20,6 +20,12 @@ export type * from './types/windows'
 export type * from './types/styles'
 export type * from './types/bookmarks'
 export type * from './types/history'
+export type * from './types/external-api'
+export {
+  EXTERNAL_API_MESSAGE_TYPE,
+  EXTERNAL_API_VERSION,
+  ExternalApiRequestError,
+} from './types/external-api'
 
 export interface ConfirmDialog {
   type: E.ConfirmationType

--- a/src/types/external-api.ts
+++ b/src/types/external-api.ts
@@ -1,0 +1,105 @@
+export const EXTERNAL_API_VERSION = 1 as const
+export const EXTERNAL_API_MESSAGE_TYPE = 'sidebery-api' as const
+
+export type ExternalApiMethod =
+  'get-state' | 'move-tabs' | 'create-group' | 'remove-group' | 'rename-group' | 'flatten-tabs'
+
+export interface ExternalApiRequest {
+  type: typeof EXTERNAL_API_MESSAGE_TYPE
+  version: typeof EXTERNAL_API_VERSION
+  method: ExternalApiMethod
+  windowId: ID
+  params?: unknown
+}
+
+export interface ExternalApiError {
+  code: string
+  message: string
+}
+
+export class ExternalApiRequestError extends Error {
+  code: string
+
+  constructor(code: string, message: string) {
+    super(message)
+    this.name = 'ExternalApiRequestError'
+    this.code = code
+  }
+}
+
+export type ExternalApiResponse =
+  | {
+      type: typeof EXTERNAL_API_MESSAGE_TYPE
+      version: typeof EXTERNAL_API_VERSION
+      ok: true
+      result: unknown
+    }
+  | {
+      type: typeof EXTERNAL_API_MESSAGE_TYPE
+      version: typeof EXTERNAL_API_VERSION
+      ok: false
+      error: ExternalApiError
+    }
+
+export type ExternalApiPanelType = 'tabs' | 'bookmarks' | 'history' | 'sync'
+
+export interface ExternalApiPanel {
+  id: ID
+  index: number
+  type: ExternalApiPanelType
+  name: string
+  color: browser.ColorName
+}
+
+export interface ExternalApiTab {
+  id: ID
+  index: number
+  panelId: ID
+  parentId: ID | null
+  ancestorIds: ID[]
+  childIds: ID[]
+  level: number
+  pinned: boolean
+  folded: boolean
+  isParent: boolean
+  isGroup: boolean
+}
+
+export interface ExternalApiState {
+  windowId: ID
+  activePanelId: ID
+  panels: ExternalApiPanel[]
+  tabs: ExternalApiTab[]
+}
+
+export interface ExternalApiMoveTabsParams {
+  tabIds: ID[]
+  panelId?: ID
+  parentId?: ID | null
+  beforeTabId?: ID
+  afterTabId?: ID
+}
+
+export interface ExternalApiCreateGroupParams {
+  tabIds: ID[]
+  title: string
+}
+
+export interface ExternalApiRemoveGroupParams {
+  groupTabId: ID
+}
+
+export interface ExternalApiRenameGroupParams {
+  groupTabId: ID
+  title: string
+}
+
+export interface ExternalApiFlattenTabsParams {
+  tabIds: ID[]
+}
+
+export interface ExternalApiMutationResult {
+  tabs: ExternalApiTab[]
+  groupTabId?: ID
+  removedGroupTabId?: ID
+}

--- a/src/types/ipc.ts
+++ b/src/types/ipc.ts
@@ -14,6 +14,7 @@ import type * as SidebarBg from 'src/services/sidebar.bg'
 import type * as SidebarFg from 'src/services/sidebar.fg'
 import type * as ContainersBg from 'src/services/containers.bg'
 import type * as GroupPage from 'src/page.group/group'
+import type * as ExternalApiFg from 'src/services/external-api.fg'
 
 export interface Message<T extends E.InstanceType, A extends ActionsKeys<T>> {
   id?: ID
@@ -86,6 +87,7 @@ export type PanelConfigPopupActions = {
 }
 
 export type SidebarActions = {
+  externalApiRequest: typeof ExternalApiFg.handleIpcRequest
   reloadTab: (tab: T.Tab) => void
   queryTab: (props: Partial<T.Tab>) => T.Tab | null
   getTabs: (tabIds?: ID[]) => T.Tab[] | undefined

--- a/src/types/web-ext.d.ts
+++ b/src/types/web-ext.d.ts
@@ -104,10 +104,12 @@ declare namespace browser {
     function reload(): void
 
     type MessageListener = <I, O>(msg: I) => Promise<O>
+    type ExternalMessageListener = (msg: unknown, sender: Sender) => unknown
     type ConnectListener = (port: Port) => void
     type UpdateAvailableListener = (details: UpdateDetails) => void
 
     const onMessage: PortEventTarget
+    const onMessageExternal: EventTarget<ExternalMessageListener>
     const onConnect: PortEventTarget
     const onUpdateAvailable: EventTarget<UpdateAvailableListener>
   }

--- a/tests/ipc-setup.ts
+++ b/tests/ipc-setup.ts
@@ -3,7 +3,7 @@ import { vi } from 'vitest'
 vi.mock('src/services/ipc', () => {
   return {
     connectTo: () => {},
-    sidebar: () => {},
+    sidebar: vi.fn(),
     sendToSidebar: () => {},
     sidebars: () => {},
     sendToSidebars: () => {},
@@ -20,6 +20,7 @@ vi.mock('src/services/ipc', () => {
     broadcast: () => {},
     onConnected: () => {},
     onDisconnected: () => {},
+    isConnected: vi.fn(),
     disconnectFrom: () => {},
   }
 })


### PR DESCRIPTION
## Why

Firefox's tabs API does not expose Sidebery's panels, groups, or tree structure. Other extensions therefore cannot understand or safely modify the organization users maintain in Sidebery without depending on private storage.

This addresses the integration use cases discussed in [#616](https://github.com/mbnuqw/sidebery/issues/616).

## Scope

This adds a typed extension-to-extension API. Exposes panel and tab-hierarchy state, supports moving branches, managing groups, and flattening hierarchy through Sidebery's existing services.

The change includes request validation, structured errors, documentation, and tests.

Firefox accepts messages from any installed extension by default, so this creates a general integration surface rather than an allowlisted one. Open to suggestion here.

## Validation

- `npm run lint.types`
- `npm test -- --run`
- `npm run build`
- `web-ext lint --source-dir addon`
