### PR TITLE
perf: snapshots: use TextEncoder instead of new Blob to fix heavy GC lag

### DIFF
--- a/src/services/snapshots.bg.ts
+++ b/src/services/snapshots.bg.ts
@@ -480,6 +480,9 @@ async function openWindow(
   await Windows.createWithTabs(items, { incognito: incognito })
 }
 
+const sizeCalcBuffer = new Uint8Array(MAX_SIZE_LIMIT * 1024 + 4)
+const sizeCalcEncoder = new TextEncoder()
+
 function limitSnapshots(snapshots: Snapshot[]): Snapshot[] | undefined {
   if (snapshots.length <= MIN_LIMITING_COUNT) return
 
@@ -507,7 +510,7 @@ function limitSnapshots(snapshots: Snapshot[]): Snapshot[] | undefined {
     const snapshot = snapshots[index]
     if (!snapshot) continue
 
-    sizeAccum += encoder.encode(JSON.stringify(snapshot)).length
+    sizeAccum += sizeCalcEncoder.encodeInto(JSON.stringify(snapshot), sizeCalcBuffer).written
 
     if (unit === 'snap') {
       accum++

--- a/src/services/snapshots.bg.ts
+++ b/src/services/snapshots.bg.ts
@@ -502,7 +502,6 @@ function limitSnapshots(snapshots: Snapshot[]): Snapshot[] | undefined {
     normLimit = limit * 1024
   }
 
-  const encoder = new TextEncoder()
   let index = snapshots.length
   let accum = 0
   let sizeAccum = 0

--- a/src/services/snapshots.bg.ts
+++ b/src/services/snapshots.bg.ts
@@ -499,6 +499,7 @@ function limitSnapshots(snapshots: Snapshot[]): Snapshot[] | undefined {
     normLimit = limit * 1024
   }
 
+  const encoder = new TextEncoder()
   let index = snapshots.length
   let accum = 0
   let sizeAccum = 0
@@ -506,7 +507,7 @@ function limitSnapshots(snapshots: Snapshot[]): Snapshot[] | undefined {
     const snapshot = snapshots[index]
     if (!snapshot) continue
 
-    sizeAccum += new Blob([JSON.stringify(snapshot)]).size
+    sizeAccum += encoder.encode(JSON.stringify(snapshot)).length
 
     if (unit === 'snap') {
       accum++


### PR DESCRIPTION
Tested for over a month in an environment with 9,000+ tabs and the Firefox profile on a traditional HDD, with a noticeable reduction in perceived lag when deleting snapshots.