### PR TITLE
2453: add cross-window panel dnd

### DIFF
--- a/src/services/drag-and-drop.fg.ts
+++ b/src/services/drag-and-drop.fg.ts
@@ -1109,6 +1109,15 @@ export async function onDrop(e: DragEvent): Promise<void> {
   const src = getSrcInfo()
   const dst = getDstInfo()
 
+  // Snapshot before any awaiting below: window A's onDragEnd schedules
+  // resetOther() -> broadcasts 'stopDrag' after 150ms, which runs
+  // onExternalStop() -> DnD.reset() here and zeroes srcIndex/dropMode.
+  const srcNavIndex = DnD.srcIndex
+  const dragPanelId = DnD.srcPanelId
+  const isCopy = DnD.dropMode === 'copy'
+  const isFromOtherWin =
+    src.windowId !== undefined && src.windowId !== D.NOID && src.windowId !== Windows.id
+
   if (Sidebar.reactive.hiddenPanelsPopup) Sidebar.closeHiddenPanelsPopup()
   if ((toTabs && !DnD.reactive.dstPin) || toBookmarks) {
     if (toTabs && Sidebar.subPanelActive && Sidebar.subPanels.bookmarks) {
@@ -1206,11 +1215,16 @@ export async function onDrop(e: DragEvent): Promise<void> {
 
   // Tabs to tabs
   if ((fromTabs && toTabs) || (fromTabs && toTabsPanel) || (fromTabsPanel && toTabs)) {
+    // A TabsPanel drag payload can now carry the panel's pinned tabs (see
+    // bar.navigation.vue). Dropping onto a tab list would unpin them here
+    // (getDstInfo sets dst.pinned=false for DropType.Tabs), which this
+    // gesture never did before - keep them out.
+    const tabsToMove = fromTabsPanel ? dndItems.filter(i => !i.pinned) : dndItems
     const reopenNeeded = isContainerChanged()
 
-    if (DnD.dropMode === 'copy') await Tabs.open(dndItems, dst)
-    else if (reopenNeeded) await Tabs.reopen(dndItems, dst)
-    else await Tabs.move(dndItems, src, dst)
+    if (DnD.dropMode === 'copy') await Tabs.open(tabsToMove, dst)
+    else if (reopenNeeded) await Tabs.reopen(tabsToMove, dst)
+    else await Tabs.move(tabsToMove, src, dst)
   }
 
   // Tabs to bookmarks
@@ -1309,12 +1323,53 @@ export async function onDrop(e: DragEvent): Promise<void> {
     Tabs.open(dndItems, dst)
   }
 
+  // TabsPanel from another window onto this window's nav bar.
+  // Panels are global config (SidebarConfig.nav/panels), so "move the panel
+  // here" means "move that panel's tabs into this window's instance of the
+  // same panel". The hovered nav button only decides the new nav order below,
+  // never the landing panel.
+  const toNavBar = toTabsPanel || toBookmarksPanel || toSync || toNav
+  if (fromTabsPanel && isFromOtherWin && toNavBar) {
+    const srcPanel = Sidebar.panelsById[dragPanelId]
+    if (Utils.isTabsPanel(srcPanel) && dndItems.length) {
+      // Before the move: makes the result visible, un-hides the panel if it's
+      // hidden in this window (activatePanel -> showPanel), and makes
+      // moveToThisWin's `panelIsActive` true so a moved active tab actually
+      // gets activated here.
+      Sidebar.activatePanel(srcPanel.id)
+
+      const pinnedItems = dndItems.filter(i => i.pinned)
+      const normalItems = dndItems.filter(i => !i.pinned)
+      const crossIncognito = DnD.srcIncognito !== Windows.incognito
+
+      if (isCopy || crossIncognito) {
+        // Tabs can't cross the private/normal boundary with browser.tabs.move,
+        // and 'copy' means leave the originals alone - both are create-here
+        // operations. dropTabCtx is deliberately not consulted: these tabs are
+        // already legitimately in the panel, re-containerising them on a plain
+        // move would needlessly throw away their session.
+        const base: T.DstPlaceInfo = { panelId: srcPanel.id }
+        if (crossIncognito) base.containerId = D.CONTAINER_ID
+        const openFn = isCopy ? Tabs.open : Tabs.reopen
+        if (pinnedItems.length) await openFn(pinnedItems, { ...base, pinned: true })
+        if (normalItems.length) await openFn(normalItems, { ...base, pinned: false })
+      } else if (src.windowId !== undefined) {
+        await Tabs.movePanelTabsToThisWin(
+          src.windowId,
+          dndItems.map(i => i.id),
+          srcPanel.id
+        )
+      }
+    }
+  }
+
   // NavItem to NavItem
   if (
     (fromTabsPanel || fromBookmarksPanel || fromNav) &&
-    (toTabsPanel || toBookmarksPanel || toNav)
+    (toTabsPanel || toBookmarksPanel || toNav) &&
+    srcNavIndex !== -1
   ) {
-    Sidebar.moveNavItem(DnD.srcIndex, dst.index ?? 0)
+    Sidebar.moveNavItem(srcNavIndex, dst.index ?? 0)
   }
 
   // Native to tabs

--- a/src/services/drag-and-drop.fg.ts
+++ b/src/services/drag-and-drop.fg.ts
@@ -44,6 +44,11 @@ export interface DragAndDropState {
   dstParentId: ID
   dstPin: boolean
   dstPanelId: ID
+  // Which side of the nav item at dstIndex to insert at. Nav-item hover only
+  // resolves a target element, not a position within it (dragenter fires once
+  // per element) - this tracks which half of that element the cursor is over,
+  // so a single, lone nav item can still be a drop target on either side.
+  dstNavSide: 'before' | 'after'
 
   dragTooltipTitle: string
   dragTooltipInfo: string
@@ -61,6 +66,7 @@ export let reactive: DragAndDropState = {
   dstParentId: D.NOID,
   dstPanelId: D.NOID,
   dstPin: false,
+  dstNavSide: 'before',
   dragTooltipTitle: '',
   dragTooltipInfo: '',
 }
@@ -208,6 +214,7 @@ export function reset(): void {
   reactive.dstPanelId = D.NOID
   reactive.dstPin = false
   reactive.dstParentId = D.NOID
+  reactive.dstNavSide = 'before'
 
   reactive.isStarted = false
 
@@ -443,6 +450,19 @@ function isNativeTabs(event: DragEvent): boolean {
   return event.dataTransfer.types.includes('text/x-moz-text-internal')
 }
 
+// Nav items only resolve as a drop target as a whole element (dragenter fires
+// once per element, not per pixel), so without this a lone/single nav item can
+// only ever be a drop target on whichever side its raw array index happens to
+// put it relative to the dragged item - never the other side. Splitting by
+// cursor position against the element's own midpoint fixes that for both the
+// initial dragenter and any further movement within the same element.
+function computeNavItemSide(e: DragEvent, rect: DOMRect): 'before' | 'after' {
+  if (Settings.state.navBarLayout === 'vertical') {
+    return e.clientY < rect.top + rect.height / 2 ? 'before' : 'after'
+  }
+  return e.clientX < rect.left + rect.width / 2 ? 'before' : 'after'
+}
+
 function isContainerChanged(): boolean {
   // Check private container
   if (DnD.srcIncognito !== Windows.incognito) return true
@@ -617,6 +637,10 @@ export function onDragEnter(e: DragEvent): void {
         if (id === 'add_tp') DnD.reactive.dstPanelId = id
       }
       DnD.reactive.dstIndex = Sidebar.reactive.nav.indexOf(id)
+      DnD.reactive.dstNavSide = computeNavItemSide(
+        e,
+        (e.target as HTMLElement).getBoundingClientRect()
+      )
 
       const srcIsNav =
         DnD.srcType === E.DragType.NavItem ||
@@ -634,6 +658,10 @@ export function onDragEnter(e: DragEvent): void {
     DnD.reactive.dstType = E.DropType.TabsPanel
     DnD.reactive.dstPanelId = id
     DnD.reactive.dstIndex = Sidebar.reactive.nav.indexOf(id)
+    DnD.reactive.dstNavSide = computeNavItemSide(
+      e,
+      (e.target as HTMLElement).getBoundingClientRect()
+    )
   }
 
   // Close hidden panels bar
@@ -690,6 +718,18 @@ export function onDragEnter(e: DragEvent): void {
     DnD.reactive.dstPanelId = panelId ?? D.NOID
     DnD.reactive.dstPin = false
   }
+}
+
+// Live update of which side of a nav item is targeted, so moving the cursor
+// within the same (possibly lone) nav item - without leaving and re-entering
+// it - still updates the before/after indicator and the eventual drop index.
+export function onNavItemDragOver(e: DragEvent, id: ID): void {
+  if (!DnD.reactive.isStarted) return
+  if (Sidebar.reactive.nav[DnD.reactive.dstIndex] !== id) return
+  DnD.reactive.dstNavSide = computeNavItemSide(
+    e,
+    (e.currentTarget as HTMLElement).getBoundingClientRect()
+  )
 }
 
 export function onDragLeave(e: DragEvent): void {
@@ -1115,6 +1155,7 @@ export async function onDrop(e: DragEvent): Promise<void> {
   const srcNavIndex = DnD.srcIndex
   const dragPanelId = DnD.srcPanelId
   const isCopy = DnD.dropMode === 'copy'
+  const dstNavSide = DnD.reactive.dstNavSide
   const isFromOtherWin =
     src.windowId !== undefined && src.windowId !== D.NOID && src.windowId !== Windows.id
 
@@ -1369,7 +1410,14 @@ export async function onDrop(e: DragEvent): Promise<void> {
     (toTabsPanel || toBookmarksPanel || toNav) &&
     srcNavIndex !== -1
   ) {
-    Sidebar.moveNavItem(srcNavIndex, dst.index ?? 0)
+    // dst.index is the raw index of the hovered item itself (nav.indexOf), not
+    // an insertion gap. Turn it into one using which side was hovered, then
+    // adjust for the source's own removal shifting everything after it back
+    // by one (standard splice-move arithmetic - see Sidebar.moveNavItem).
+    const rawHoveredIndex = dst.index ?? 0
+    const gapIndex = dstNavSide === 'after' ? rawHoveredIndex + 1 : rawHoveredIndex
+    const finalNavIndex = gapIndex > srcNavIndex ? gapIndex - 1 : gapIndex
+    Sidebar.moveNavItem(srcNavIndex, finalNavIndex)
   }
 
   // Native to tabs

--- a/src/services/tabs.fg.move.ts
+++ b/src/services/tabs.fg.move.ts
@@ -632,7 +632,7 @@ export async function movePanelTabsToThisWin(
     Logs.warn('Tabs.movePanelTabsToThisWin: Cannot detach tabs from the source sidebar')
   }
 
-  // Fallback: the source sidebar is not connected (mirrors Tabs.move:56-66)
+  // Fallback: the source sidebar is not connected (mirrors Tabs.move)
   if (!externalTabs) {
     const winNativeTabs = await browser.tabs.query({ windowId: srcWinId })
     externalTabs = []

--- a/src/services/tabs.fg.move.ts
+++ b/src/services/tabs.fg.move.ts
@@ -599,6 +599,69 @@ export async function moveToThisWin(
   return true
 }
 
+/**
+ * Pull all tabs of a panel from another window into this window's instance of
+ * the same (global) panel.
+ *
+ * Pinned and normal tabs are moved in two passes because `moveToThisWin` applies
+ * a single `dst.pinned` to the whole batch. The detach itself is a single IPC
+ * round-trip so `allInWin` stays correct for the whole set and the second pass
+ * can't clobber `Tabs.detachingTabIds` while the first pass' native move is
+ * still in flight (that set is replaced, not merged, on each `detachTabs` call).
+ */
+export async function movePanelTabsToThisWin(
+  srcWinId: ID,
+  tabIds: ID[],
+  dstPanelId: ID
+): Promise<void> {
+  if (!tabIds.length) return
+  if (srcWinId === NOID || srcWinId === Windows.id) return
+
+  const dstPanel = Sidebar.panelsById[dstPanelId]
+  if (!Utils.isTabsPanel(dstPanel)) {
+    return Logs.warn('Tabs.movePanelTabsToThisWin: no dst tabs panel', dstPanelId)
+  }
+
+  let externalTabs: T.Tab[] | undefined
+  let allInWin = false
+  try {
+    const info = await IPC.bg('detachSidebarTabs', srcWinId, tabIds)
+    externalTabs = info?.tabs
+    allInWin = !!info?.allInWin
+  } catch {
+    Logs.warn('Tabs.movePanelTabsToThisWin: Cannot detach tabs from the source sidebar')
+  }
+
+  // Fallback: the source sidebar is not connected (mirrors Tabs.move:56-66)
+  if (!externalTabs) {
+    const winNativeTabs = await browser.tabs.query({ windowId: srcWinId })
+    externalTabs = []
+    for (const id of tabIds) {
+      const nativeTab = winNativeTabs.find(t => t.id === id)
+      if (!nativeTab) continue
+      const tab = Tabs.mutateNativeTabToSideberyTab(nativeTab)
+      tab.panelId = dstPanelId
+      externalTabs.push(tab)
+    }
+    allInWin = winNativeTabs.length > 0 && winNativeTabs.length === externalTabs.length
+  }
+  if (!externalTabs.length) return
+
+  const pinned = externalTabs.filter(t => t.pinned)
+  const normal = externalTabs.filter(t => !t.pinned)
+
+  // dst.index is intentionally left undefined - moveToThisWin derives the right
+  // one per batch (Tabs.pinned.length / panel.nextTabIndex) at run time.
+  // allInWin (window-closing logic) applies to the last non-empty batch only.
+  if (pinned.length) {
+    const isLast = !normal.length
+    await Tabs.moveToThisWin(pinned, { panelId: dstPanelId, pinned: true }, isLast && allInWin)
+  }
+  if (normal.length) {
+    await Tabs.moveToThisWin(normal, { panelId: dstPanelId, pinned: false }, allInWin)
+  }
+}
+
 export interface DetachedTabsInfo {
   tabs: T.Tab[]
   allInWin: boolean
@@ -688,7 +751,7 @@ export function detachTabs(tabIds: ID[]): DetachedTabsInfo | undefined {
   Tabs.updateTabsIndexes()
   Tabs.updateTabsTree()
   Sidebar.recalcTabsPanels()
-  if (!probeTab.pinned) Sidebar.recalcVisibleTabs(panel.id)
+  if (detachedTabs.some(t => !t.pinned)) Sidebar.recalcVisibleTabs(panel.id)
   if (toSave.length) toSave.forEach(id => Tabs.saveTabData(id))
 
   // Save new tabs cache

--- a/src/sidebar/components/bar.navigation.vue
+++ b/src/sidebar/components/bar.navigation.vue
@@ -687,7 +687,7 @@ function onNavDragStart(e: DragEvent, item: T.NavItem) {
   if (isTabsPanel || isBookmarksPanel) Sidebar.updateBounds()
   Selection.selectNavItem(item.id)
 
-  const contentList = []
+  const contentList: (string | undefined)[] = []
   const dragItems: T.DragItem[] = []
   const dragInfo: T.DragInfo = {
     type: dndType,
@@ -702,11 +702,12 @@ function onNavDragStart(e: DragEvent, item: T.NavItem) {
 
   if (Utils.isTabsPanel(panel)) {
     dragInfo.panelId = panel.id
-    for (const tab of panel.tabs) {
+
+    const addItem = (tab: T.Tab, pinned: boolean): void => {
       contentList.push(tab.title)
       contentList.push(tab.url)
       contentList.push('')
-      dragItems.push({
+      const dragItem: T.DragItem = {
         id: tab.id,
         url: tab.url,
         title: tab.title,
@@ -715,8 +716,18 @@ function onNavDragStart(e: DragEvent, item: T.NavItem) {
         customColor: tab.customColor,
         customTitle: tab.customTitle,
         folded: tab.folded,
-      })
+      }
+      if (pinned) dragItem.pinned = true
+      dragItems.push(dragItem)
     }
+
+    // Panel-scoped pinned tabs belong to the panel, so they're a part of the
+    // drag payload too (globally-pinned tabs are not). Keep them first so a
+    // moved/copied/reopened batch preserves a valid pinned-then-normal order.
+    if (Settings.state.pinnedTabsPosition === 'panel') {
+      for (const tab of panel.pinnedTabs) addItem(tab, true)
+    }
+    for (const tab of panel.tabs) addItem(tab, false)
   } else {
     dragItems.push({ id: item.id })
   }

--- a/src/sidebar/components/nav-item.vue
+++ b/src/sidebar/components/nav-item.vue
@@ -18,6 +18,7 @@
   :data-drop-mode="dropPointerMode(item.id)"
   :title="item.reactive.tooltip || item.reactive.name"
   @dragstart="emit('dragstart', $event)"
+  @dragover.prevent="DnD.onNavItemDragOver($event, item.id)"
   @drop="emit('drop', $event)"
   @mousedown.stop="emit('mousedown', $event)"
   @mouseup.stop="emit('mouseup', $event)"
@@ -50,6 +51,7 @@
   :data-drop-mode="dropPointerMode(item.id)"
   :title="item.reactive.tooltip || item.reactive.name"
   @dragstart="emit('dragstart', $event)"
+  @dragover.prevent="DnD.onNavItemDragOver($event, item.id)"
   @drop="emit('drop', $event)"
   @mousedown.stop="emit('mousedown', $event)"
   @mouseup.stop="emit('mouseup', $event)"
@@ -73,6 +75,7 @@
   :data-drop-mode="dropPointerMode(item.id)"
   :title="item.tooltip || item.name"
   @dragstart="emit('dragstart', $event)"
+  @dragover.prevent="DnD.onNavItemDragOver($event, item.id)"
   @drop="emit('drop', $event)"
   @mousedown.stop="emit('mousedown', $event)"
   @mouseup.stop="emit('mouseup', $event)"
@@ -90,6 +93,7 @@
   :data-sel="item.id === Sidebar.reactive.selectedNavId"
   :data-drop-mode="dropPointerMode(item.id)"
   @dragstart="emit('dragstart', $event)"
+  @dragover.prevent="DnD.onNavItemDragOver($event, item.id)"
   @drop="emit('drop', $event)"
   @mousedown="emit('mousedown', $event)"
   @mouseup="emit('mouseup', $event)"
@@ -154,12 +158,9 @@ function dropPointerMode(id: ID): string {
   const dstId = Sidebar.reactive.nav[DnD.reactive.dstIndex]
   if (dstIsNavItem && dstId === id) {
     if (srcIsNavItem) {
-      if (DnD.srcIndex !== -1 && DnD.reactive.dstIndex !== -1) {
-        if (DnD.reactive.dstIndex < DnD.srcIndex) return 'before'
-        if (DnD.reactive.dstIndex === DnD.srcIndex) return 'none'
-        if (DnD.reactive.dstIndex > DnD.srcIndex) return 'after'
-      }
-      return 'before'
+      // Hovering the item that's being dragged itself - no-op.
+      if (DnD.reactive.dstIndex === DnD.srcIndex) return 'none'
+      return DnD.reactive.dstNavSide
     } else {
       if (DnD.reactive.dstType !== E.DropType.NavItem || id === 'add_tp') return 'in'
     }


### PR DESCRIPTION
Closes https://github.com/mbnuqw/sidebery/issues/2453

# Summary

Right now, you can only drag a panel into the tabs section to open its tabs in that panel.

This PR adds cross-window panel drag-and-drop: dragging a tabs-panel nav button from one browser window's panel section onto another window's panel section.

Also fixes an existing bug where the dnd line between panels (previously unfunctional) would only show on the left when the target window has only one panel. Now that it's functional it matters so was fixed.

# Demo

https://github.com/user-attachments/assets/be293a0f-b49f-414d-a2e2-7780a20a6fe8

# Key decisions:

1. Tabs always land in the same panel in the destination window as they were in the target, regardless of which nav button was the drop target. This aligns with current same-window panel dnd, where dragging one panel onto another doesn't move tabs to it.
2. Panel-scoped pinned tabs (pinnedTabsPosition === 'panel') move with the panel; globally-pinned tabs never move.
3. Tabs.move()'s cross-window pull branch calls moveToThisWin(...) without await — so naively awaiting Tabs.move() twice (once for pinned, once for normal, since moveToThisWin applies one pinned flag per batch) would race: overlapping detachTabs calls clobber Tabs.detachingTabIds (replaced, not merged) and read stale panel.nextTabIndex. Adds a new Tabs.movePanelTabsToThisWin() that does one detachSidebarTabs IPC call, partitions the returned tabs, then calls the properly-awaitable Tabs.moveToThisWin() twice sequentially.

# Changes

- `tabs.fg.move.ts`: added movePanelTabsToThisWin(); fixed a latent detachTabs bug where recalcVisibleTabs was gated on probeTab.pinned instead of the batch actually containing normal tabs.
- `bar.navigation.vue`: panel drag payload now includes panel-scoped pinned tabs (pinned-first ordering, load-bearing for downstream browser.tabs.move calls); fixed a pre-existing implicit-any[] type issue on contentList exposed by refactoring the push logic into a closure.
- `drag-and-drop.fg.ts`: new branch — external panel drop onto any nav-bar target activates/un-hides the panel then moves its tabs (splitting copy-mode and cross-incognito into Tabs.open/Tabs.reopen, deliberately skipping dropTabCtx re-containerization since tabs are already legitimately in P); snapshotted srcIndex/srcPanelId/dropMode before the first await since a 150ms-delayed stopDrag broadcast can reset shared DnD state mid-handler; guarded the existing panel→tab-list path so newly-included pinned items don't get silently unpinned there; nav-reorder now runs after the tab move (ordering is load-bearing — moveNavItem's updateSidebar re-sorts native tab order and would otherwise race the panel move).
